### PR TITLE
fix: undefined method 'new' for BigDecimal:Class

### DIFF
--- a/docs/2.5.0/Nanook.html
+++ b/docs/2.5.0/Nanook.html
@@ -10,11 +10,11 @@
   
 </title>
 
-  <link rel="stylesheet" href="css/style.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="css/style.css" type="text/css" />
 
-  <link rel="stylesheet" href="css/common.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="css/common.css" type="text/css" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = "Nanook";
   relpath = '';
 </script>
@@ -106,9 +106,7 @@
     
 <h4 id="label-Initializing">Initializing</h4>
 
-<p>Connect to the default RPC host at <a
-href="http://localhost:7076">localhost:7076</a> and with a timeout of 500
-seconds:</p>
+<p>Connect to the default RPC host at <a href="http://localhost:7076">localhost:7076</a> and with a timeout of 500 seconds:</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_nanook'>nanook</span> <span class='op'>=</span> <span class='const'>Nanook</span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span>
 </code></pre>
@@ -141,25 +139,31 @@ seconds:</p>
   
 </p>
 
-  <h2>Constant Summary</h2>
-  <dl class="constants">
-    
-      <dt id="UNITS-constant" class="">UNITS =
-        
-      </dt>
-      <dd><pre class="code"><span class='lbracket'>[</span><span class='symbol'>:raw</span><span class='comma'>,</span> <span class='symbol'>:nano</span><span class='rbracket'>]</span></pre></dd>
-    
-      <dt id="DEFAULT_UNIT-constant" class="">DEFAULT_UNIT =
-        
-      </dt>
-      <dd><pre class="code"><span class='symbol'>:nano</span></pre></dd>
-    
-      <dt id="VERSION-constant" class="">VERSION =
-        
-      </dt>
-      <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>2.5.0</span><span class='tstring_end'>&quot;</span></span></pre></dd>
-    
-  </dl>
+  
+    <h2>
+      Constant Summary
+      <small><a href="#" class="constants_summary_toggle">collapse</a></small>
+    </h2>
+
+    <dl class="constants">
+      
+        <dt id="UNITS-constant" class="">UNITS =
+          
+        </dt>
+        <dd><pre class="code"><span class='lbracket'>[</span><span class='symbol'>:raw</span><span class='comma'>,</span> <span class='symbol'>:nano</span><span class='rbracket'>]</span></pre></dd>
+      
+        <dt id="DEFAULT_UNIT-constant" class="">DEFAULT_UNIT =
+          
+        </dt>
+        <dd><pre class="code"><span class='symbol'>:nano</span></pre></dd>
+      
+        <dt id="VERSION-constant" class="">VERSION =
+          
+        </dt>
+        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>2.5.0</span><span class='tstring_end'>&quot;</span></span></pre></dd>
+      
+    </dl>
+  
 
 
 
@@ -454,8 +458,7 @@ seconds:</p>
 
 <h4 id="label-Examples-3A">Examples:</h4>
 
-<p>Connecting to <a href="http://localhost:7076">localhost:7076</a> with the
-default timeout of 10s:</p>
+<p>Connecting to <a href="http://localhost:7076">localhost:7076</a> with the default timeout of 10s:</p>
 
 <pre class="code ruby"><code class="ruby"><span class='const'><span class='object_link'><a href="" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span>
 </code></pre>
@@ -503,11 +506,12 @@ default timeout of 10s:</p>
         <span class='type'>(<tt>Integer</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook::Rpc::DEFAULT_TIMEOUT</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="Nanook/Rpc.html#DEFAULT_TIMEOUT-constant" title="Nanook::Rpc::DEFAULT_TIMEOUT (constant)">Nanook::Rpc::DEFAULT_TIMEOUT</a></span>. Connection timeout in number of
-seconds</p>
+<p>default is <span class='object_link'><a href="Nanook/Rpc.html#DEFAULT_TIMEOUT-constant" title="Nanook::Rpc::DEFAULT_TIMEOUT (constant)">Nanook::Rpc::DEFAULT_TIMEOUT</a></span>. Connection timeout in number of seconds</p>
 </div>
       
     </li>
@@ -614,9 +618,7 @@ seconds</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns the default unit for amounts to be in. will return <span class='object_link'><a href="#DEFAULT_UNIT-constant" title="Nanook::DEFAULT_UNIT (constant)">DEFAULT_UNIT</a></span>
-unless you define a new constant Nanook::UNIT (which must be one of
-<span class='object_link'><a href="#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>)</p>
+<p>Returns the default unit for amounts to be in. will return <span class='object_link'><a href="#DEFAULT_UNIT-constant" title="Nanook::DEFAULT_UNIT (constant)">DEFAULT_UNIT</a></span> unless you define a new constant Nanook::UNIT (which must be one of <span class='object_link'><a href="#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>).</p>
 
 
   </div>
@@ -635,8 +637,7 @@ unless you define a new constant Nanook::UNIT (which must be one of
       
         &mdash;
         <div class='inline'>
-<p>the default unit for amounts to be in. will return <span class='object_link'><a href="#DEFAULT_UNIT-constant" title="Nanook::DEFAULT_UNIT (constant)">DEFAULT_UNIT</a></span> unless
-you define a new constant Nanook::UNIT (which must be one of <span class='object_link'><a href="#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>)</p>
+<p>the default unit for amounts to be in. will return <span class='object_link'><a href="#DEFAULT_UNIT-constant" title="Nanook::DEFAULT_UNIT (constant)">DEFAULT_UNIT</a></span> unless you define a new constant Nanook::UNIT (which must be one of <span class='object_link'><a href="#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>)</p>
 </div>
       
     </li>
@@ -1177,9 +1178,9 @@ you define a new constant Nanook::UNIT (which must be one of <span class='object
 </div>
 
       <div id="footer">
-  Generated on Mon Sep 16 06:30:34 2019 by
+  Generated on Fri Mar 26 12:47:23 2021 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.5.3).
+  0.9.24 (ruby-3.0.0).
 </div>
 
     </div>

--- a/docs/2.5.0/Nanook/Account.html
+++ b/docs/2.5.0/Nanook/Account.html
@@ -10,11 +10,11 @@
   
 </title>
 
-  <link rel="stylesheet" href="../css/style.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/style.css" type="text/css" />
 
-  <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/common.css" type="text/css" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = "Nanook::Account";
   relpath = '../';
 </script>
@@ -102,8 +102,7 @@
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
     
-<p>The <code>Nanook::Account</code> class contains methods to discover
-publicly-available information about accounts on the nano network.</p>
+<p>The <code>Nanook::Account</code> class contains methods to discover publicly-available information about accounts on the nano network.</p>
 
 <h3 id="label-Initializing">Initializing</h3>
 
@@ -206,8 +205,7 @@ publicly-available information about accounts on the nano network.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Information about this accounts that have set this account as their
-representative.</p>
+<p>Information about this accounts that have set this account as their representative.</p>
 </div></span>
   
 </li>
@@ -377,8 +375,7 @@ representative.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>The last modified time of the account in the time zone of your nano node
-(usually UTC).</p>
+<p>The last modified time of the account in the time zone of your nano node (usually UTC).</p>
 </div></span>
   
 </li>
@@ -402,8 +399,7 @@ representative.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Information about the given account as well as other accounts up the
-ledger.</p>
+<p>Information about the given account as well as other accounts up the ledger.</p>
 </div></span>
   
 </li>
@@ -427,8 +423,7 @@ ledger.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Information about pending blocks (payments) that are waiting to be received
-by the account.</p>
+<p>Information about pending blocks (payments) that are waiting to be received by the account.</p>
 </div></span>
   
 </li>
@@ -524,7 +519,7 @@ by the account.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns a new instance of Account</p>
+<p>Returns a new instance of Account.</p>
 
 
   </div>
@@ -574,8 +569,7 @@ by the account.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>The account&#39;s balance, including pending (unreceived payments). To
-receive a pending amount see <span class='object_link'><a href="WalletAccount.html#receive-instance_method" title="Nanook::WalletAccount#receive (method)">WalletAccount#receive</a></span>.</p>
+<p>The account&#39;s balance, including pending (unreceived payments). To receive a pending amount see <span class='object_link'><a href="WalletAccount.html#receive-instance_method" title="Nanook::WalletAccount#receive (method)">WalletAccount#receive</a></span>.</p>
 
 <h4 id="label-Examples-3A">Examples:</h4>
 
@@ -618,13 +612,12 @@ receive a pending amount see <span class='object_link'><a href="WalletAccount.ht
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -714,7 +707,7 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns number of blocks for this account</p>
+<p>Returns number of blocks for this account.</p>
 
 
   </div>
@@ -773,8 +766,7 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Information about this accounts that have set this account as their
-representative.</p>
+<p>Information about this accounts that have set this account as their representative.</p>
 
 <h3 id="label-Example-3A">Example:</h3>
 
@@ -804,13 +796,12 @@ representative.</p>
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -903,14 +894,9 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
     
 <p>Returns true if the account has an <em>open</em> block.</p>
 
-<p>An open block gets published when an account receives a payment for the
-first time.</p>
+<p>An open block gets published when an account receives a payment for the first time.</p>
 
-<p>The reliability of this check depends on the node host having synchronized
-itself with most of the blocks on the nano network, otherwise you may get
-<code>false</code> when the account does exist. You can check if a
-node&#39;s  synchronization is particular low using
-<span class='object_link'><a href="Node.html#sync_progress-instance_method" title="Nanook::Node#sync_progress (method)">Node#sync_progress</a></span>.</p>
+<p>The reliability of this check depends on the node host having synchronized itself with most of the blocks on the nano network, otherwise you may get <code>false</code> when the account does exist. You can check if a node&#39;s  synchronization is particular low using <span class='object_link'><a href="Node.html#sync_progress-instance_method" title="Nanook::Node#sync_progress (method)">Node#sync_progress</a></span>.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1012,6 +998,8 @@ node&#39;s  synchronization is particular low using
         <span class='type'>(<tt>Integer</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>1000</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
@@ -1028,13 +1016,12 @@ node&#39;s  synchronization is particular low using
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -1240,11 +1227,12 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
         <span class='type'>(<tt>Boolean</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>false</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>(default is false). When <code>true</code>, four additional calls are made
-to the RPC to return more information</p>
+<p>(default is false). When <code>true</code>, four additional calls are made to the RPC to return more information</p>
 </div>
       
     </li>
@@ -1257,13 +1245,12 @@ to the RPC to return more information</p>
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -1291,8 +1278,7 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
 <p>The latest block hash</p>
 </dd><dt><code>open_block</code>
 <dd>
-<p>The first block in every account&#39;s blockchain. When this block was
-published the account was officially open</p>
+<p>The first block in every account&#39;s blockchain. When this block was published the account was officially open</p>
 </dd><dt><code>representative_block</code>
 <dd>
 <p>The block that named the representative for the account</p>
@@ -1307,9 +1293,7 @@ published the account was officially open</p>
 <p>Number of blocks in the account&#39;s blockchain</p>
 </dd></dl>
 
-<p>When <code>detailed: true</code> is passed as an argument, this method
-makes four additional calls to the RPC to return more information about an
-account:</p>
+<p>When <code>detailed: true</code> is passed as an argument, this method makes four additional calls to the RPC to return more information about an account:</p>
 <dl class="rdoc-list label-list"><dt><code>weight</code>
 <dd>
 <p>See <span class='object_link'><a href="#weight-instance_method" title="Nanook::Account#weight (method)">#weight</a></span></p>
@@ -1438,8 +1422,7 @@ account:</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>The last modified time of the account in the time zone of your nano node
-(usually UTC).</p>
+<p>The last modified time of the account in the time zone of your nano node (usually UTC).</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1463,8 +1446,7 @@ account:</p>
       
         &mdash;
         <div class='inline'>
-<p>last modified time of the account in the time zone of your nano node
-(usually UTC).</p>
+<p>last modified time of the account in the time zone of your nano node (usually UTC).</p>
 </div>
       
     </li>
@@ -1506,9 +1488,7 @@ account:</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Information about the given account as well as other accounts up the
-ledger. The number of accounts returned is determined by the
-<code>limit:</code> argument.</p>
+<p>Information about the given account as well as other accounts up the ledger. The number of accounts returned is determined by the <code>limit:</code> argument.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1545,6 +1525,8 @@ ledger. The number of accounts returned is determined by the
         <span class='type'>(<tt>Integer</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>1</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
@@ -1560,6 +1542,8 @@ ledger. The number of accounts returned is determined by the
       
         <span class='type'>(<tt>Time</tt>)</span>
       
+      
+        <em class="default">(defaults to: <tt>nil</tt>)</em>
       
       
         &mdash;
@@ -1577,13 +1561,12 @@ ledger. The number of accounts returned is determined by the
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -1677,16 +1660,13 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Information about pending blocks (payments) that are waiting to be received
-by the account.</p>
+<p>Information about pending blocks (payments) that are waiting to be received by the account.</p>
 
-<p>See also the <span class='object_link'><a href="WalletAccount.html#receive-instance_method" title="Nanook::WalletAccount#receive (method)">WalletAccount#receive</a></span> method for how to receive a
-pending payment.</p>
+<p>See also the <span class='object_link'><a href="WalletAccount.html#receive-instance_method" title="Nanook::WalletAccount#receive (method)">WalletAccount#receive</a></span> method for how to receive a pending payment.</p>
 
 <p>The default response is an Array of block ids.</p>
 
-<p>With the <code>detailed:</code> argument, the method returns an Array of
-Hashes, which contain the source account id, amount pending and block id.</p>
+<p>With the <code>detailed:</code> argument, the method returns an Array of Hashes, which contain the source account id, amount pending and block id.</p>
 
 <h4 id="label-Examples-3A">Examples:</h4>
 
@@ -1725,6 +1705,8 @@ Hashes, which contain the source account id, amount pending and block id.</p>
         <span class='type'>(<tt>Integer</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>1000</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
@@ -1741,11 +1723,12 @@ Hashes, which contain the source account id, amount pending and block id.</p>
         <span class='type'>(<tt>Boolean</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>false</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>return a more complex Hash of pending block information (default is
-<code>false</code>)</p>
+<p>return a more complex Hash of pending block information (default is <code>false</code>)</p>
 </div>
       
     </li>
@@ -1758,13 +1741,12 @@ Hashes, which contain the source account id, amount pending and block id.</p>
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -1931,8 +1913,7 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>The representative account id for the account. Representatives are accounts
-that cast votes in the case of a fork in the network.</p>
+<p>The representative account id for the account. Representatives are accounts that cast votes in the case of a fork in the network.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1998,9 +1979,7 @@ that cast votes in the case of a fork in the network.</p>
     
 <p>The account&#39;s weight.</p>
 
-<p>Weight is determined by the account&#39;s balance, and represents the
-voting weight that account has on the network. Only accounts with greater
-than 256 weight can vote.</p>
+<p>Weight is determined by the account&#39;s balance, and represents the voting weight that account has on the network. Only accounts with greater than 256 weight can vote.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -2057,9 +2036,9 @@ than 256 weight can vote.</p>
 </div>
 
       <div id="footer">
-  Generated on Mon Sep 16 06:30:35 2019 by
+  Generated on Fri Mar 26 12:47:25 2021 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.5.3).
+  0.9.24 (ruby-3.0.0).
 </div>
 
     </div>

--- a/docs/2.5.0/Nanook/Block.html
+++ b/docs/2.5.0/Nanook/Block.html
@@ -10,11 +10,11 @@
   
 </title>
 
-  <link rel="stylesheet" href="../css/style.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/style.css" type="text/css" />
 
-  <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/common.css" type="text/css" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = "Nanook::Block";
   relpath = '../';
 </script>
@@ -102,8 +102,7 @@
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
     
-<p>The <code>Nanook::Block</code> class contains methods to discover
-publicly-available information about blocks on the nano network.</p>
+<p>The <code>Nanook::Block</code> class contains methods to discover publicly-available information about blocks on the nano network.</p>
 
 <p>A block is represented by a unique id like this:</p>
 
@@ -211,9 +210,7 @@ publicly-available information about blocks on the nano network.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Returns a consecutive list of block hashes in the account chain starting at
-block back to count (direction from frontier back to open block, from newer
-blocks to older).</p>
+<p>Returns a consecutive list of block hashes in the account chain starting at block back to count (direction from frontier back to open block, from newer blocks to older).</p>
 </div></span>
   
 </li>
@@ -311,8 +308,7 @@ blocks to older).</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Returns Array of Hashes containing information about a chain of
-send/receive blocks, starting from this block.</p>
+<p>Returns Array of Hashes containing information about a chain of send/receive blocks, starting from this block.</p>
 </div></span>
   
 </li>
@@ -506,8 +502,7 @@ send/receive blocks, starting from this block.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Republish blocks starting at this block up the account chain back to the
-nano network.</p>
+<p>Republish blocks starting at this block up the account chain back to the nano network.</p>
 </div></span>
   
 </li>
@@ -555,7 +550,7 @@ nano network.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns a new instance of Block</p>
+<p>Returns a new instance of Block.</p>
 
 
   </div>
@@ -739,11 +734,7 @@ nano network.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns a consecutive list of block hashes in the account chain starting at
-block back to count (direction from frontier back to open block, from newer
-blocks to older). Will list all blocks back to the open block of this chain
-when count is set to “-1”. The requested block hash is included in the
-answer.</p>
+<p>Returns a consecutive list of block hashes in the account chain starting at block back to count (direction from frontier back to open block, from newer blocks to older). Will list all blocks back to the open block of this chain when count is set to “-1”. The requested block hash is included in the answer.</p>
 
 <p>See also #successors.</p>
 
@@ -775,6 +766,8 @@ answer.</p>
         <span class='type'>(<tt>Integer</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>1000</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
@@ -791,11 +784,12 @@ answer.</p>
         <span class='type'>(<tt>Integer</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>0</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>return the account chain block hashes offset by the specified number of
-blocks (default is 0)</p>
+<p>return the account chain block hashes offset by the specified number of blocks (default is 0)</p>
 </div>
       
     </li>
@@ -838,12 +832,7 @@ blocks (default is 0)</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Request confirmation for a block from online representative nodes. Will
-return immediately with a boolean to indicate if the request for
-confirmation was successful. Note that this boolean does not indicate the
-confirmation status of the block. If confirmed, your block should appear in
-<span class='object_link'><a href="Node.html#confirmation_history-instance_method" title="Nanook::Node#confirmation_history (method)">Node#confirmation_history</a></span> within a short amount of time, or you
-can use the convenience method <span class='object_link'><a href="#confirmed_recently%3F-instance_method" title="Nanook::Block#confirmed_recently? (method)">#confirmed_recently?</a></span></p>
+<p>Request confirmation for a block from online representative nodes. Will return immediately with a boolean to indicate if the request for confirmation was successful. Note that this boolean does not indicate the confirmation status of the block. If confirmed, your block should appear in <span class='object_link'><a href="Node.html#confirmation_history-instance_method" title="Nanook::Node#confirmation_history (method)">Node#confirmation_history</a></span> within a short amount of time, or you can use the convenience method <span class='object_link'><a href="#confirmed_recently%3F-instance_method" title="Nanook::Block#confirmed_recently? (method)">#confirmed_recently?</a></span></p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -911,21 +900,13 @@ can use the convenience method <span class='object_link'><a href="#confirmed_rec
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>This call is for internal diagnostics/debug purposes only. Do not rely on
-this interface being stable and do not use in a production system.</p>
+<p>This call is for internal diagnostics/debug purposes only. Do not rely on this interface being stable and do not use in a production system.</p>
 
-<p>Check if the block appears in the list of recently confirmed blocks by
-online representatives. The full list of blocks can be queried for with
-<span class='object_link'><a href="Node.html#confirmation_history-instance_method" title="Nanook::Node#confirmation_history (method)">Node#confirmation_history</a></span>.</p>
+<p>Check if the block appears in the list of recently confirmed blocks by online representatives. The full list of blocks can be queried for with <span class='object_link'><a href="Node.html#confirmation_history-instance_method" title="Nanook::Node#confirmation_history (method)">Node#confirmation_history</a></span>.</p>
 
-<p>This method can work in conjunction with <span class='object_link'><a href="#confirm-instance_method" title="Nanook::Block#confirm (method)">#confirm</a></span>, whereby
-you can send any block (old or new) out to online representatives to
-confirm. The confirmation process can take up to a couple of minutes.</p>
+<p>This method can work in conjunction with <span class='object_link'><a href="#confirm-instance_method" title="Nanook::Block#confirm (method)">#confirm</a></span>, whereby you can send any block (old or new) out to online representatives to confirm. The confirmation process can take up to a couple of minutes.</p>
 
-<p>The method returning <code>false</code> can indicate that the block is
-still in the process of being confirmed and that you should call the method
-again soon, or that it was confirmed earlier than the list available in
-<span class='object_link'><a href="Node.html#confirmation_history-instance_method" title="Nanook::Node#confirmation_history (method)">Node#confirmation_history</a></span>, or that it was not confirmed.</p>
+<p>The method returning <code>false</code> can indicate that the block is still in the process of being confirmed and that you should call the method again soon, or that it was confirmed earlier than the list available in <span class='object_link'><a href="Node.html#confirmation_history-instance_method" title="Nanook::Node#confirmation_history (method)">Node#confirmation_history</a></span>, or that it was not confirmed.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -949,8 +930,7 @@ again soon, or that it was confirmed earlier than the list available in
       
         &mdash;
         <div class='inline'>
-<p><code>true</code> if the block has been recently confirmed by online
-representatives.</p>
+<p><code>true</code> if the block has been recently confirmed by online representatives.</p>
 </div>
       
     </li>
@@ -1012,12 +992,12 @@ representatives.</p>
         <span class='type'>(<tt>Boolean</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>false</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>if set to <code>true</code>, then the node will query its work peers (if it
-has any, see <span class='object_link'><a href="WorkPeer.html#list-instance_method" title="Nanook::WorkPeer#list (method)">WorkPeer#list</a></span>). When <code>false</code>, the node
-will only generate work locally (default is <code>false</code>)</p>
+<p>if set to <code>true</code>, then the node will query its work peers (if it has any, see <span class='object_link'><a href="WorkPeer.html#list-instance_method" title="Nanook::WorkPeer#list (method)">WorkPeer#list</a></span>). When <code>false</code>, the node will only generate work locally (default is <code>false</code>)</p>
 </div>
       
     </li>
@@ -1076,8 +1056,7 @@ will only generate work locally (default is <code>false</code>)</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns Array of Hashes containing information about a chain of
-send/receive blocks, starting from this block.</p>
+<p>Returns Array of Hashes containing information about a chain of send/receive blocks, starting from this block.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1111,11 +1090,12 @@ send/receive blocks, starting from this block.</p>
         <span class='type'>(<tt>Integer</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>1000</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>maximum number of send/receive block hashes to return in the chain (default
-is 1000)</p>
+<p>maximum number of send/receive block hashes to return in the chain (default is 1000)</p>
 </div>
       
     </li>
@@ -1256,11 +1236,12 @@ is 1000)</p>
         <span class='type'>(<tt>Boolean</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>false</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>(default is <code>false</code>). If <code>true</code>, information can be
-returned about blocks that are unchecked (unverified).</p>
+<p>(default is <code>false</code>). If <code>true</code>, information can be returned about blocks that are unchecked (unverified).</p>
 </div>
       
     </li>
@@ -1295,9 +1276,9 @@ returned about blocks that are unchecked (unverified).</p>
     <span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='id identifier rubyid_rpc'>rpc</span><span class='lparen'>(</span><span class='symbol'>:unchecked_get</span><span class='comma'>,</span> <span class='symbol'>:hash</span><span class='rparen'>)</span>
     <span class='kw'>unless</span> <span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_has_key?'>has_key?</span><span class='lparen'>(</span><span class='symbol'>:error</span><span class='rparen'>)</span>
       <span class='kw'>return</span> <span class='id identifier rubyid__parse_info_response'>_parse_info_response</span><span class='lparen'>(</span><span class='id identifier rubyid_response'>response</span><span class='rparen'>)</span>
-    <span class='kw'>end</span>
-    <span class='comment'># If unchecked not found, continue to checked block
-</span>  <span class='kw'>end</span>
+    <span class='kw'>end</span>    <span class='comment'># If unchecked not found, continue to checked block
+</span>
+  <span class='kw'>end</span>
 
   <span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='id identifier rubyid_rpc'>rpc</span><span class='lparen'>(</span><span class='symbol'>:block</span><span class='comma'>,</span> <span class='symbol'>:hash</span><span class='rparen'>)</span>
   <span class='id identifier rubyid__parse_info_response'>_parse_info_response</span><span class='lparen'>(</span><span class='id identifier rubyid_response'>response</span><span class='rparen'>)</span>
@@ -1567,8 +1548,7 @@ returned about blocks that are unchecked (unverified).</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Republish blocks starting at this block up the account chain back to the
-nano network.</p>
+<p>Republish blocks starting at this block up the account chain back to the nano network.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1686,11 +1666,12 @@ nano network.</p>
         <span class='type'>(<tt>Integer</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>1000</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>maximum number of send/receive block hashes to return in the chain (default
-is 1000)</p>
+<p>maximum number of send/receive block hashes to return in the chain (default is 1000)</p>
 </div>
       
     </li>
@@ -1703,11 +1684,12 @@ is 1000)</p>
         <span class='type'>(<tt>Integer</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>0</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>return the account chain block hashes offset by the specified number of
-blocks (default is 0)</p>
+<p>return the account chain block hashes offset by the specified number of blocks (default is 0)</p>
 </div>
       
     </li>
@@ -1761,9 +1743,9 @@ blocks (default is 0)</p>
 </div>
 
       <div id="footer">
-  Generated on Mon Sep 16 06:30:34 2019 by
+  Generated on Fri Mar 26 12:47:24 2021 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.5.3).
+  0.9.24 (ruby-3.0.0).
 </div>
 
     </div>

--- a/docs/2.5.0/Nanook/Error.html
+++ b/docs/2.5.0/Nanook/Error.html
@@ -10,11 +10,11 @@
   
 </title>
 
-  <link rel="stylesheet" href="../css/style.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/style.css" type="text/css" />
 
-  <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/common.css" type="text/css" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = "Nanook::Error";
   relpath = '../';
 </script>
@@ -125,9 +125,9 @@
 </div>
 
       <div id="footer">
-  Generated on Mon Sep 16 06:30:34 2019 by
+  Generated on Fri Mar 26 12:47:24 2021 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.5.3).
+  0.9.24 (ruby-3.0.0).
 </div>
 
     </div>

--- a/docs/2.5.0/Nanook/Key.html
+++ b/docs/2.5.0/Nanook/Key.html
@@ -10,11 +10,11 @@
   
 </title>
 
-  <link rel="stylesheet" href="../css/style.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/style.css" type="text/css" />
 
-  <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/common.css" type="text/css" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = "Nanook::Key";
   relpath = '../';
 </script>
@@ -246,7 +246,7 @@
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns a new instance of Key</p>
+<p>Returns a new instance of Key.</p>
 
 
   </div>
@@ -423,9 +423,9 @@
 </div>
 
       <div id="footer">
-  Generated on Mon Sep 16 06:30:34 2019 by
+  Generated on Fri Mar 26 12:47:23 2021 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.5.3).
+  0.9.24 (ruby-3.0.0).
 </div>
 
     </div>

--- a/docs/2.5.0/Nanook/Node.html
+++ b/docs/2.5.0/Nanook/Node.html
@@ -10,11 +10,11 @@
   
 </title>
 
-  <link rel="stylesheet" href="../css/style.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/style.css" type="text/css" />
 
-  <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/common.css" type="text/css" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = "Nanook::Node";
   relpath = '../';
 </script>
@@ -102,19 +102,11 @@
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
     
-<p>The <code>Nanook::Node</code> class contains methods to manage your nano
-node and query its data of the nano network.</p>
+<p>The <code>Nanook::Node</code> class contains methods to manage your nano node and query its data of the nano network.</p>
 
-<p>Your node is constantly syncing data with other nodes on the network. When
-your node first starts up after being built, its database will be empty and
-it will begin synchronizing and downloading data of the nano ledger to its
-local database. The ledger is the central record of all accounts and
-transactions. Some of the methods in this class query your node&#39;s
-database formed from the nano ledger, and so the responses are determined
-by the completeness of your node&#39;s database.</p>
+<p>Your node is constantly syncing data with other nodes on the network. When your node first starts up after being built, its database will be empty and it will begin synchronizing and downloading data of the nano ledger to its local database. The ledger is the central record of all accounts and transactions. Some of the methods in this class query your node&#39;s database formed from the nano ledger, and so the responses are determined by the completeness of your node&#39;s database.</p>
 
-<p>You can determine how synchronized your node is with the nano ledger with
-the <span class='object_link'><a href="#sync_progress-instance_method" title="Nanook::Node#sync_progress (method)">#sync_progress</a></span> method.</p>
+<p>You can determine how synchronized your node is with the nano ledger with the <span class='object_link'><a href="#sync_progress-instance_method" title="Nanook::Node#sync_progress (method)">#sync_progress</a></span> method.</p>
 
 <h3 id="label-Initializing">Initializing</h3>
 
@@ -170,8 +162,7 @@ the <span class='object_link'><a href="#sync_progress-instance_method" title="Na
 
   
     <span class="summary_desc"><div class='inline'>
-<p>The number of accounts in the nano ledger–essentially all accounts with
-<em>open</em> blocks.</p>
+<p>The number of accounts in the nano ledger–essentially all accounts with <em>open</em> blocks.</p>
 </div></span>
   
 </li>
@@ -195,8 +186,7 @@ the <span class='object_link'><a href="#sync_progress-instance_method" title="Na
 
   
     <span class="summary_desc"><div class='inline'>
-<p>The count of all blocks downloaded to the node, and blocks still to be
-synchronized by the node.</p>
+<p>The count of all blocks downloaded to the node, and blocks still to be synchronized by the node.</p>
 </div></span>
   
 </li>
@@ -366,12 +356,7 @@ synchronized by the node.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Returns the difficulty values (16 hexadecimal digits string, 64 bit) for
-the minimum required on the network (network_minimum) as well as the
-current active difficulty seen on the network (network_current, 5 minute
-trended average of adjusted difficulty seen on confirmed transactions)
-which can be used to perform rework for better prioritization of
-transaction processing.</p>
+<p>Returns the difficulty values (16 hexadecimal digits string, 64 bit) for the minimum required on the network (network_minimum) as well as the current active difficulty seen on the network (network_current, 5 minute trended average of adjusted difficulty seen on confirmed transactions) which can be used to perform rework for better prioritization of transaction processing.</p>
 </div></span>
   
 </li>
@@ -537,8 +522,7 @@ transaction processing.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>The percentage completeness of the synchronization process for your node as
-it downloads the nano ledger.</p>
+<p>The percentage completeness of the synchronization process for your node as it downloads the nano ledger.</p>
 </div></span>
   
 </li>
@@ -562,8 +546,7 @@ it downloads the nano ledger.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>This method is deprecated and will be removed in 3.0, as a node never
-reaches 100% synchronization.</p>
+<p>This method is deprecated and will be removed in 3.0, as a node never reaches 100% synchronization.</p>
 </div></span>
   
 </li>
@@ -663,7 +646,7 @@ reaches 100% synchronization.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns a new instance of Node</p>
+<p>Returns a new instance of Node.</p>
 
 
   </div>
@@ -715,12 +698,7 @@ reaches 100% synchronization.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>The number of accounts in the nano ledger–essentially all accounts with
-<em>open</em> blocks. An <em>open</em> block is the type of block written
-to the nano ledger when an account receives its first payment (see
-<span class='object_link'><a href="WalletAccount.html#receive-instance_method" title="Nanook::WalletAccount#receive (method)">WalletAccount#receive</a></span>). All accounts that respond
-<code>true</code> to <span class='object_link'><a href="Account.html#exists%3F-instance_method" title="Nanook::Account#exists? (method)">Account#exists?</a></span> have open blocks in the
-ledger.</p>
+<p>The number of accounts in the nano ledger–essentially all accounts with <em>open</em> blocks. An <em>open</em> block is the type of block written to the nano ledger when an account receives its first payment (see <span class='object_link'><a href="WalletAccount.html#receive-instance_method" title="Nanook::WalletAccount#receive (method)">WalletAccount#receive</a></span>). All accounts that respond <code>true</code> to <span class='object_link'><a href="Account.html#exists%3F-instance_method" title="Nanook::Account#exists? (method)">Account#exists?</a></span> have open blocks in the ledger.</p>
 
 
   </div>
@@ -779,8 +757,7 @@ ledger.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>The count of all blocks downloaded to the node, and blocks still to be
-synchronized by the node.</p>
+<p>The count of all blocks downloaded to the node, and blocks still to be synchronized by the node.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1065,6 +1042,8 @@ synchronized by the node.</p>
         <span class='type'>(<tt>Boolean</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>false</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
@@ -1127,9 +1106,7 @@ synchronized by the node.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returning status of current bootstrap attempt for debug purposes only. This
-call is for internal diagnostics/debug purposes only. Do not rely on this
-interface being stable and do not use in a production system.</p>
+<p>Returning status of current bootstrap attempt for debug purposes only. This call is for internal diagnostics/debug purposes only. Do not rely on this interface being stable and do not use in a production system.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1209,12 +1186,9 @@ interface being stable and do not use in a production system.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>This call is for internal diagnostics/debug purposes only. Do not rely on
-this interface being stable and do not use in a production system.</p>
+<p>This call is for internal diagnostics/debug purposes only. Do not rely on this interface being stable and do not use in a production system.</p>
 
-<p>Returns block and tally weight (in raw) election duration (in
-milliseconds), election confirmation timestamp for recent elections
-winners.</p>
+<p>Returns block and tally weight (in raw) election duration (in milliseconds), election confirmation timestamp for recent elections winners.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1299,13 +1273,7 @@ winners.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns the difficulty values (16 hexadecimal digits string, 64 bit) for
-the minimum required on the network (network_minimum) as well as the
-current active difficulty seen on the network (network_current, 5 minute
-trended average of adjusted difficulty seen on confirmed transactions)
-which can be used to perform rework for better prioritization of
-transaction processing. A multiplier of the network_current from the base
-difficulty of network_minimum is also provided for comparison.</p>
+<p>Returns the difficulty values (16 hexadecimal digits string, 64 bit) for the minimum required on the network (network_minimum) as well as the current active difficulty seen on the network (network_current, 5 minute trended average of adjusted difficulty seen on confirmed transactions) which can be used to perform rework for better prioritization of transaction processing. A multiplier of the network_current from the base difficulty of network_minimum is also provided for comparison.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1342,12 +1310,12 @@ difficulty of network_minimum is also provided for comparison.</p>
         <span class='type'>(<tt>Boolean</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>false</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>false by default. Also returns the trend of difficulty seen on the network
-as a list of multipliers. Sampling occurs every 16 to 36 seconds. The list
-is ordered such that the first value is the most recent sample.</p>
+<p>false by default. Also returns the trend of difficulty seen on the network as a list of multipliers. Sampling occurs every 16 to 36 seconds. The list is ordered such that the first value is the most recent sample.</p>
 </div>
       
     </li>
@@ -1594,9 +1562,7 @@ is ordered such that the first value is the most recent sample.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>All online representatives that have voted recently. Note, due to the
-design of the nano RPC, this method cannot return the voting weight of the
-representatives.</p>
+<p>All online representatives that have voted recently. Note, due to the design of the nano RPC, this method cannot return the voting weight of the representatives.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1719,10 +1685,7 @@ representatives.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>The percentage completeness of the synchronization process for your node as
-it downloads the nano ledger. Note, it&#39;s normal for your progress to
-not ever reach 100. The closer to 100, the more complete your node&#39;s
-data is, and so the query methods in this class become more reliable.</p>
+<p>The percentage completeness of the synchronization process for your node as it downloads the nano ledger. Note, it&#39;s normal for your progress to not ever reach 100. The closer to 100, the more complete your node&#39;s data is, and so the query methods in this class become more reliable.</p>
 
 
   </div>
@@ -1793,8 +1756,7 @@ data is, and so the query methods in this class become more reliable.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>This method is deprecated and will be removed in 3.0, as a node never
-reaches 100% synchronization.</p>
+<p>This method is deprecated and will be removed in 3.0, as a node never reaches 100% synchronization.</p>
 
 
   </div>
@@ -1859,7 +1821,7 @@ reaches 100% synchronization.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns information about the synchronizing blocks for this node</p>
+<p>Returns information about the synchronizing blocks for this node.</p>
 
 
   </div>
@@ -1875,6 +1837,8 @@ reaches 100% synchronization.</p>
       
         <span class='type'>(<tt>Integer</tt>)</span>
       
+      
+        <em class="default">(defaults to: <tt>1000</tt>)</em>
       
       
         &mdash;
@@ -2009,7 +1973,7 @@ reaches 100% synchronization.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns version information for this node</p>
+<p>Returns version information for this node.</p>
 
 
   </div>
@@ -2061,9 +2025,9 @@ reaches 100% synchronization.</p>
 </div>
 
       <div id="footer">
-  Generated on Mon Sep 16 06:30:34 2019 by
+  Generated on Fri Mar 26 12:47:24 2021 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.5.3).
+  0.9.24 (ruby-3.0.0).
 </div>
 
     </div>

--- a/docs/2.5.0/Nanook/Rpc.html
+++ b/docs/2.5.0/Nanook/Rpc.html
@@ -10,11 +10,11 @@
   
 </title>
 
-  <link rel="stylesheet" href="../css/style.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/style.css" type="text/css" />
 
-  <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/common.css" type="text/css" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = "Nanook::Rpc";
   relpath = '../';
 </script>
@@ -102,13 +102,9 @@
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
     
-<p>The <code>Nanook::Rpc</code> class is responsible for maintaining the
-connection to the RPC server, calling the RPC and parsing its response into
-Ruby primitives.</p>
+<p>The <code>Nanook::Rpc</code> class is responsible for maintaining the connection to the RPC server, calling the RPC and parsing its response into Ruby primitives.</p>
 
-<p>Internally, the <span class='object_link'><a href="../Nanook.html" title="Nanook (class)">Nanook</a></span> class creates an instance of this class, and
-it&#39;s generally more convenient to interact with the RPC through an
-instance of <span class='object_link'><a href="../Nanook.html#rpc-instance_method" title="Nanook#rpc (method)">#rpc</a></span> instead of by instantiating this class directly:</p>
+<p>Internally, the <span class='object_link'><a href="../Nanook.html" title="Nanook (class)">Nanook</a></span> class creates an instance of this class, and it&#39;s generally more convenient to interact with the RPC through an instance of <span class='object_link'><a href="../Nanook.html#rpc-instance_method" title="Nanook#rpc (method)">#rpc</a></span> instead of by instantiating this class directly:</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_nanook'>nanook</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="../Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="../Nanook.html#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span>
 <span class='id identifier rubyid_nanook'>nanook</span><span class='period'>.</span><span class='id identifier rubyid_rpc'>rpc</span><span class='lparen'>(</span><span class='symbol'>:accounts_create</span><span class='comma'>,</span> <span class='label'>wallet:</span> <span class='id identifier rubyid_wallet_id'>wallet_id</span><span class='comma'>,</span> <span class='label'>count:</span> <span class='int'>2</span><span class='rparen'>)</span>
@@ -121,11 +117,16 @@ instance of <span class='object_link'><a href="../Nanook.html#rpc-instance_metho
   
 
 </div>
-  <h2>Constant Summary</h2>
-  <dl class="constants">
-    
-      <dt id="DEFAULT_URI-constant" class="">DEFAULT_URI =
-        <div class="docstring">
+  
+    <h2>
+      Constant Summary
+      <small><a href="#" class="constants_summary_toggle">collapse</a></small>
+    </h2>
+
+    <dl class="constants">
+      
+        <dt id="DEFAULT_URI-constant" class="">DEFAULT_URI =
+          <div class="docstring">
   <div class="discussion">
     
 <p>Default RPC server and port to connect to</p>
@@ -137,11 +138,11 @@ instance of <span class='object_link'><a href="../Nanook.html#rpc-instance_metho
   
 
 </div>
-      </dt>
-      <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>http://localhost:7076</span><span class='tstring_end'>&quot;</span></span></pre></dd>
-    
-      <dt id="DEFAULT_TIMEOUT-constant" class="">DEFAULT_TIMEOUT =
-        <div class="docstring">
+        </dt>
+        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>http://localhost:7076</span><span class='tstring_end'>&quot;</span></span></pre></dd>
+      
+        <dt id="DEFAULT_TIMEOUT-constant" class="">DEFAULT_TIMEOUT =
+          <div class="docstring">
   <div class="discussion">
     
 <p>Default request timeout in seconds</p>
@@ -153,10 +154,11 @@ instance of <span class='object_link'><a href="../Nanook.html#rpc-instance_metho
   
 
 </div>
-      </dt>
-      <dd><pre class="code"><span class='int'>60</span></pre></dd>
-    
-  </dl>
+        </dt>
+        <dd><pre class="code"><span class='int'>60</span></pre></dd>
+      
+    </dl>
+  
 
 
 
@@ -262,7 +264,7 @@ instance of <span class='object_link'><a href="../Nanook.html#rpc-instance_metho
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns a new instance of Rpc</p>
+<p>Returns a new instance of Rpc.</p>
 
 
   </div>
@@ -348,8 +350,7 @@ instance of <span class='object_link'><a href="../Nanook.html#rpc-instance_metho
       
         &mdash;
         <div class='inline'>
-<p>the “action” of the RPC to call. The RPC always expects an “action” param
-to identify what RPC action is being called.</p>
+<p>the “action” of the RPC to call. The RPC always expects an “action” param to identify what RPC action is being called.</p>
 </div>
       
     </li>
@@ -495,9 +496,9 @@ to identify what RPC action is being called.</p>
 </div>
 
       <div id="footer">
-  Generated on Mon Sep 16 06:30:34 2019 by
+  Generated on Fri Mar 26 12:47:23 2021 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.5.3).
+  0.9.24 (ruby-3.0.0).
 </div>
 
     </div>

--- a/docs/2.5.0/Nanook/Util.html
+++ b/docs/2.5.0/Nanook/Util.html
@@ -10,11 +10,11 @@
   
 </title>
 
-  <link rel="stylesheet" href="../css/style.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/style.css" type="text/css" />
 
-  <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/common.css" type="text/css" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = "Nanook::Util";
   relpath = '../';
 </script>
@@ -111,11 +111,16 @@
   
 
 </div>
-  <h2>Constant Summary</h2>
-  <dl class="constants">
-    
-      <dt id="STEP-constant" class="">STEP =
-        <div class="docstring">
+  
+    <h2>
+      Constant Summary
+      <small><a href="#" class="constants_summary_toggle">collapse</a></small>
+    </h2>
+
+    <dl class="constants">
+      
+        <dt id="STEP-constant" class="">STEP =
+          <div class="docstring">
   <div class="discussion">
     
 <p>Constant used to convert back and forth between raw and NANO.</p>
@@ -127,10 +132,11 @@
   
 
 </div>
-      </dt>
-      <dd><pre class="code"><span class='const'>BigDecimal</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>10</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span><span class='op'>**</span><span class='const'>BigDecimal</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>30</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span></pre></dd>
-    
-  </dl>
+        </dt>
+        <dd><pre class="code"><span class='const'>BigDecimal</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>10</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span><span class='op'>**</span><span class='const'>BigDecimal</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>30</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span></pre></dd>
+      
+    </dl>
+  
 
 
 
@@ -241,9 +247,7 @@
     
 <p>Converts an empty String value into an empty version of another type.</p>
 
-<p>The RPC often returns an empty String (<code>&quot;&quot;</code>) as a
-value, when a <code>nil</code>, or empty Array (<code>[]</code>), or empty
-Hash (<code>{}</code>) would be better. If the response might be</p>
+<p>The RPC often returns an empty String (<code>&quot;&quot;</code>) as a value, when a <code>nil</code>, or empty Array (<code>[]</code>), or empty Hash (<code>{}</code>) would be better. If the response might be</p>
 
 
   </div>
@@ -388,7 +392,7 @@ Hash (<code>{}</code>) would be better. If the response might be</p>
       <pre class="code"><span class="info file"># File 'lib/nanook/util.rb', line 15</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='const'>NANO_to_raw</span><span class='lparen'>(</span><span class='id identifier rubyid_nano'>nano</span><span class='rparen'>)</span>
-  <span class='lparen'>(</span><span class='const'>BigDecimal</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_nano'>nano</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span><span class='rparen'>)</span> <span class='op'>*</span> <span class='const'><span class='object_link'><a href="#STEP-constant" title="Nanook::Util::STEP (constant)">STEP</a></span></span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_i'>to_i</span>
+  <span class='lparen'>(</span><span class='const'>BigDecimal</span><span class='lparen'>(</span><span class='id identifier rubyid_nano'>nano</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span><span class='rparen'>)</span> <span class='op'>*</span> <span class='const'><span class='object_link'><a href="#STEP-constant" title="Nanook::Util::STEP (constant)">STEP</a></span></span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_i'>to_i</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -479,9 +483,9 @@ Hash (<code>{}</code>) would be better. If the response might be</p>
 </div>
 
       <div id="footer">
-  Generated on Mon Sep 16 06:30:34 2019 by
+  Generated on Fri Mar 26 12:47:24 2021 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.5.3).
+  0.9.24 (ruby-3.0.0).
 </div>
 
     </div>

--- a/docs/2.5.0/Nanook/Wallet.html
+++ b/docs/2.5.0/Nanook/Wallet.html
@@ -10,11 +10,11 @@
   
 </title>
 
-  <link rel="stylesheet" href="../css/style.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/style.css" type="text/css" />
 
-  <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/common.css" type="text/css" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = "Nanook::Wallet";
   relpath = '../';
 </script>
@@ -102,41 +102,20 @@
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
     
-<p>The <code>Nanook::Wallet</code> class lets you manage your nano wallets, as
-well as some account-specific things like making and receiving payments.</p>
+<p>The <code>Nanook::Wallet</code> class lets you manage your nano wallets, as well as some account-specific things like making and receiving payments.</p>
 
 <h3 id="label-Wallet+seeds+vs+ids">Wallet seeds vs ids</h3>
 
-<p>Your wallets each have an id as well as a seed. Both are 32-byte uppercase
-hex strings that look like this:</p>
+<p>Your wallets each have an id as well as a seed. Both are 32-byte uppercase hex strings that look like this:</p>
 
 <pre class="code ruby"><code class="ruby">000D1BAEC8EC208142C99059B393051BAC8380F9B5A2E6B2489A277D81789F3F
 </code></pre>
 
-<p>This class uses wallet <em>ids</em> to identify your wallet. A wallet id
-only exists locally on the nano node that it was created on. The person who
-knows this id can only perform all read and write actions against the
-wallet and all accounts inside the wallet from the same nano node that it
-was created on. This makes wallet ids fairly safe to use as a person needs
-to know your wallet id as well as have access to run RPC commands against
-your nano node to be able to control your accounts.</p>
+<p>This class uses wallet <em>ids</em> to identify your wallet. A wallet id only exists locally on the nano node that it was created on. The person who knows this id can only perform all read and write actions against the wallet and all accounts inside the wallet from the same nano node that it was created on. This makes wallet ids fairly safe to use as a person needs to know your wallet id as well as have access to run RPC commands against your nano node to be able to control your accounts.</p>
 
-<p>A <em>seed</em> on the other hand can be used to link any wallet to another
-wallet&#39;s accounts, from anywhere in the nano network. This happens by
-setting a wallet&#39;s seed to be the same as a previous wallet&#39;s seed.
-When a wallet has the same seed as another wallet, any accounts created in
-the second wallet will be the same accounts as those that were created in
-the previous wallet, and the new wallet&#39;s owner will also gain
-ownership of the previous wallet&#39;s accounts. Note, that the two wallets
-will have different ids, but the same seed.</p>
+<p>A <em>seed</em> on the other hand can be used to link any wallet to another wallet&#39;s accounts, from anywhere in the nano network. This happens by setting a wallet&#39;s seed to be the same as a previous wallet&#39;s seed. When a wallet has the same seed as another wallet, any accounts created in the second wallet will be the same accounts as those that were created in the previous wallet, and the new wallet&#39;s owner will also gain ownership of the previous wallet&#39;s accounts. Note, that the two wallets will have different ids, but the same seed.</p>
 
-<p>Nanook is based on the Nano RPC, which uses wallet ids and not seeds. The
-RPC and therefore Nanook cannot tell you what a wallet&#39;s seed is, only
-its id. Knowing a wallet&#39;s seed is very useful for if you ever want to
-restore the wallet anywhere else on the nano network besides the node you
-originally created it on. The nano command line interface (CLI) is the only
-method for discovering a wallet&#39;s seed. See the
-<a href="https://docs.nano.org/commands/command-line-interface/#-wallet_decrypt_unsafe-walletwallet-passwordpassword" target="_parent" title="https://docs.nano.org/commands/command-line-interface/#-wallet_decrypt_unsafe-walletwallet-passwordpassword">https://docs.nano.org/commands/command-line-interface/#-wallet_decrypt_unsafe-walletwallet-passwordpassword</a>.</p>
+<p>Nanook is based on the Nano RPC, which uses wallet ids and not seeds. The RPC and therefore Nanook cannot tell you what a wallet&#39;s seed is, only its id. Knowing a wallet&#39;s seed is very useful for if you ever want to restore the wallet anywhere else on the nano network besides the node you originally created it on. The nano command line interface (CLI) is the only method for discovering a wallet&#39;s seed. See the <a href="https://docs.nano.org/commands/command-line-interface/#-wallet_decrypt_unsafe-walletwallet-passwordpassword" target="_parent" title="https://docs.nano.org/commands/command-line-interface/#-wallet_decrypt_unsafe-walletwallet-passwordpassword">https://docs.nano.org/commands/command-line-interface/#-wallet_decrypt_unsafe-walletwallet-passwordpassword</a>.</p>
 
 <h3 id="label-Initializing">Initializing</h3>
 
@@ -191,8 +170,7 @@ method for discovering a wallet&#39;s seed. See the
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Returns the given account in the wallet as a <span class='object_link'><a href="WalletAccount.html" title="Nanook::WalletAccount (class)">WalletAccount</a></span>
-instance to let you start working with it.</p>
+<p>Returns the given account in the wallet as a <span class='object_link'><a href="WalletAccount.html" title="Nanook::WalletAccount (class)">WalletAccount</a></span> instance to let you start working with it.</p>
 </div></span>
   
 </li>
@@ -240,8 +218,7 @@ instance to let you start working with it.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Balance of all accounts in the wallet, optionally breaking the balances
-down by account.</p>
+<p>Balance of all accounts in the wallet, optionally breaking the balances down by account.</p>
 </div></span>
   
 </li>
@@ -605,8 +582,7 @@ down by account.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Makes a payment from an account in your wallet to another account on the
-nano network.</p>
+<p>Makes a payment from an account in your wallet to another account on the nano network.</p>
 </div></span>
   
 </li>
@@ -630,8 +606,7 @@ nano network.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Information about pending blocks (payments) that are waiting to be received
-by accounts in this wallet.</p>
+<p>Information about pending blocks (payments) that are waiting to be received by accounts in this wallet.</p>
 </div></span>
   
 </li>
@@ -727,7 +702,7 @@ by accounts in this wallet.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns a new instance of Wallet</p>
+<p>Returns a new instance of Wallet.</p>
 
 
   </div>
@@ -777,17 +752,14 @@ by accounts in this wallet.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns the given account in the wallet as a <span class='object_link'><a href="WalletAccount.html" title="Nanook::WalletAccount (class)">Nanook::WalletAccount</a></span>
-instance to let you start working with it.</p>
+<p>Returns the given account in the wallet as a <span class='object_link'><a href="WalletAccount.html" title="Nanook::WalletAccount (class)">Nanook::WalletAccount</a></span> instance to let you start working with it.</p>
 
-<p>Call with no <code>account</code> argument if you wish to create a new
-account in the wallet, like this:</p>
+<p>Call with no <code>account</code> argument if you wish to create a new account in the wallet, like this:</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_wallet'>wallet</span><span class='period'>.</span><span class='id identifier rubyid_account'>account</span><span class='period'>.</span><span class='id identifier rubyid_create'>create</span>     <span class='comment'># =&gt; Nanook::WalletAccount
 </span></code></pre>
 
-<p>See <span class='object_link'><a href="WalletAccount.html" title="Nanook::WalletAccount (class)">Nanook::WalletAccount</a></span> for all the methods you can call on the account
-object returned.</p>
+<p>See <span class='object_link'><a href="WalletAccount.html" title="Nanook::WalletAccount (class)">Nanook::WalletAccount</a></span> for all the methods you can call on the account object returned.</p>
 
 <h4 id="label-Examples-3A">Examples:</h4>
 
@@ -815,10 +787,7 @@ object returned.</p>
       
         &mdash;
         <div class='inline'>
-<p>optional String of an account (starting with
-<code>&quot;xrb...&quot;</code>) to start working with. Must be an account
-within the wallet. When no account is given, the instance returned only
-allows you to call <code>create</code> on it, to create a new account.</p>
+<p>optional String of an account (starting with <code>&quot;xrb...&quot;</code>) to start working with. Must be an account within the wallet. When no account is given, the instance returned only allows you to call <code>create</code> on it, to create a new account.</p>
 </div>
       
     </li>
@@ -892,8 +861,7 @@ allows you to call <code>create</code> on it, to create a new account.</p>
     
 <p>Array of <span class='object_link'><a href="WalletAccount.html" title="Nanook::WalletAccount (class)">Nanook::WalletAccount</a></span> instances of accounts in the wallet.</p>
 
-<p>See <span class='object_link'><a href="WalletAccount.html" title="Nanook::WalletAccount (class)">Nanook::WalletAccount</a></span> for all the methods you can call on the account
-objects returned.</p>
+<p>See <span class='object_link'><a href="WalletAccount.html" title="Nanook::WalletAccount (class)">Nanook::WalletAccount</a></span> for all the methods you can call on the account objects returned.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -965,8 +933,7 @@ objects returned.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Balance of all accounts in the wallet, optionally breaking the balances
-down by account.</p>
+<p>Balance of all accounts in the wallet, optionally breaking the balances down by account.</p>
 
 <h4 id="label-Examples-3A">Examples:</h4>
 
@@ -1028,11 +995,12 @@ down by account.</p>
         <span class='type'>(<tt>Boolean</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>false</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>(default is <code>false</code>). When <code>true</code> the response will
-contain balances per account.</p>
+<p>(default is <code>false</code>). When <code>true</code> the response will contain balances per account.</p>
 </div>
       
     </li>
@@ -1045,13 +1013,12 @@ contain balances per account.</p>
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -1153,10 +1120,7 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Sets the default representative for the wallet. A wallet&#39;s default
-representative is the representative all new accounts created in the wallet
-will have. Changing the default representative for a wallet does not change
-the representatives for existing accounts in the wallet.</p>
+<p>Sets the default representative for the wallet. A wallet&#39;s default representative is the representative all new accounts created in the wallet will have. Changing the default representative for a wallet does not change the representatives for existing accounts in the wallet.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1181,8 +1145,7 @@ the representatives for existing accounts in the wallet.</p>
       
         &mdash;
         <div class='inline'>
-<p>the id of the representative account to set as this account&#39;s
-representative</p>
+<p>the id of the representative account to set as this account&#39;s representative</p>
 </div>
       
     </li>
@@ -1357,8 +1320,7 @@ representative</p>
     
 <p>Changes a wallet&#39;s seed.</p>
 
-<p>It&#39;s recommended to only change the seed of a wallet that contains no
-accounts.</p>
+<p>It&#39;s recommended to only change the seed of a wallet that contains no accounts.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1534,12 +1496,7 @@ accounts.</p>
     
 <p>Creates a new wallet.</p>
 
-<p>The wallet will be created only on this node. It&#39;s important that if
-you intend to add funds to accounts in this wallet that you backup the
-wallet <strong>seed</strong> in order to restore the wallet in future. The
-nano command line interface (CLI) is the only method for backing up a
-wallet&#39;s seed. See the
-<a href="https://github.com/nanocurrency/raiblocks/wiki/Command-line-interface" target="_parent" title="–wallet_decrypt_unsafe CLI command">–wallet_decrypt_unsafe CLI command</a>.</p>
+<p>The wallet will be created only on this node. It&#39;s important that if you intend to add funds to accounts in this wallet that you backup the wallet <strong>seed</strong> in order to restore the wallet in future. The nano command line interface (CLI) is the only method for backing up a wallet&#39;s seed. See the <a href="https://github.com/nanocurrency/raiblocks/wiki/Command-line-interface" target="_parent" title="–wallet_decrypt_unsafe CLI command">–wallet_decrypt_unsafe CLI command</a>.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1604,11 +1561,9 @@ wallet&#39;s seed. See the
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>The default representative account id for the wallet. This is the
-representative that all new accounts created in this wallet will have.</p>
+<p>The default representative account id for the wallet. This is the representative that all new accounts created in this wallet will have.</p>
 
-<p>Changing the default representative for a wallet does not change the
-representatives for any accounts that have been created.</p>
+<p>Changing the default representative for a wallet does not change the representatives for any accounts that have been created.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1788,7 +1743,7 @@ representatives for any accounts that have been created.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns the wallet id</p>
+<p>Returns the wallet id.</p>
 
 
   </div>
@@ -1888,13 +1843,12 @@ representatives for any accounts that have been created.</p>
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -1913,8 +1867,7 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
       
         &mdash;
         <div class='inline'>
-<p>information about the wallet. See <span class='object_link'><a href="Account.html#info-instance_method" title="Nanook::Account#info (method)">Account#info</a></span> for details of
-what is returned for each account.</p>
+<p>information about the wallet. See <span class='object_link'><a href="Account.html#info-instance_method" title="Nanook::Account#info (method)">Account#info</a></span> for details of what is returned for each account.</p>
 </div>
       
     </li>
@@ -2038,8 +1991,7 @@ what is returned for each account.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Locks the wallet. A locked wallet cannot pocket pending transactions or
-make payments. See <span class='object_link'><a href="#unlock-instance_method" title="Nanook::Wallet#unlock (method)">#unlock</a></span>.</p>
+<p>Locks the wallet. A locked wallet cannot pocket pending transactions or make payments. See <span class='object_link'><a href="#unlock-instance_method" title="Nanook::Wallet#unlock (method)">#unlock</a></span>.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -2175,16 +2127,11 @@ make payments. See <span class='object_link'><a href="#unlock-instance_method" t
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Makes a payment from an account in your wallet to another account on the
-nano network.</p>
+<p>Makes a payment from an account in your wallet to another account on the nano network.</p>
 
-<p>Note, there may be a delay in receiving a response due to Proof of Work
-being done. From the <a
-href="https://docs.nano.org/commands/rpc-protocol/#send">Nano RPC</a>:</p>
+<p>Note, there may be a delay in receiving a response due to Proof of Work being done. From the <a href="https://docs.nano.org/commands/rpc-protocol/#send">Nano RPC</a>:</p>
 
-<p><em>Proof of Work is precomputed for one transaction in the background. If
-it has been a while since your last transaction it will send instantly, the
-next one will need to wait for Proof of Work to be generated.</em></p>
+<p><em>Proof of Work is precomputed for one transaction in the background. If it has been a while since your last transaction it will send instantly, the next one will need to wait for Proof of Work to be generated.</em></p>
 
 <h4 id="label-Examples-3A">Examples:</h4>
 
@@ -2250,13 +2197,12 @@ next one will need to wait for Proof of Work to be generated.</em></p>
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -2337,11 +2283,9 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Information about pending blocks (payments) that are waiting to be received
-by accounts in this wallet.</p>
+<p>Information about pending blocks (payments) that are waiting to be received by accounts in this wallet.</p>
 
-<p>See also the <span class='object_link'><a href="#receive-instance_method" title="Nanook::Wallet#receive (method)">#receive</a></span> method of this class for how to receive a pending
-payment.</p>
+<p>See also the <span class='object_link'><a href="#receive-instance_method" title="Nanook::Wallet#receive (method)">#receive</a></span> method of this class for how to receive a pending payment.</p>
 
 <h4 id="label-Examples-3A">Examples:</h4>
 
@@ -2373,19 +2317,19 @@ payment.</p>
     <span class='lbrace'>{</span>
       <span class='symbol'>:amount</span><span class='op'>=&gt;</span><span class='float'>6.0</span><span class='comma'>,</span>
       <span class='symbol'>:source</span><span class='op'>=&gt;</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>nano_3dcfozsmekr1tr9skf1oa5wbgmxt81qepfdnt7zicq5x3hk65fg4fqj58mbr</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span>
-      <span class='symbol'>:block</span><span class='op'>=&gt;</span><span class='symbol'>:142A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D</span><span class='tstring_end'>&quot;</span></span>
+      <span class='symbol'>:block</span><span class='op'>=&gt;</span><span class='symbol'>:&quot;142A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D&quot;</span>
     <span class='rbrace'>}</span><span class='comma'>,</span>
     <span class='lbrace'>{</span>
       <span class='symbol'>:amount</span><span class='op'>=&gt;</span><span class='float'>12.0</span><span class='comma'>,</span>
       <span class='symbol'>:source</span><span class='op'>=&gt;</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>nano_3dcfozsmekr1tr9skf1oa5wbgmxt81qepfdnt7zicq5x3hk65fg4fqj58mbr</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span>
-      <span class='symbol'>:block</span><span class='op'>=&gt;</span><span class='symbol'>:242A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D</span><span class='tstring_end'>&quot;</span></span>
+      <span class='symbol'>:block</span><span class='op'>=&gt;</span><span class='symbol'>:&quot;242A538F36833D1CC78B94E11C766F75818F8B940771335C6C1B8AB880C5BB1D&quot;</span>
     <span class='rbrace'>}</span>
   <span class='rbracket'>]</span><span class='comma'>,</span>
   <span class='symbol'>:nano_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3</span><span class='op'>=&gt;</span><span class='lbracket'>[</span>
     <span class='lbrace'>{</span>
       <span class='symbol'>:amount</span><span class='op'>=&gt;</span><span class='float'>106.370018</span><span class='comma'>,</span>
       <span class='symbol'>:source</span><span class='op'>=&gt;</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>nano_13ezf4od79h1tgj9aiu4djzcmmguendtjfuhwfukhuucboua8cpoihmh8byo</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span>
-      <span class='symbol'>:block</span><span class='op'>=&gt;</span><span class='symbol'>:4C1FEEF0BEA7F50BE35489A1233FE002B212DEA554B55B1B470D78BD8F210C74</span><span class='tstring_end'>&quot;</span></span>
+      <span class='symbol'>:block</span><span class='op'>=&gt;</span><span class='symbol'>:&quot;4C1FEEF0BEA7F50BE35489A1233FE002B212DEA554B55B1B470D78BD8F210C74&quot;</span>
     <span class='rbrace'>}</span>
   <span class='rbracket'>]</span>
 <span class='rbrace'>}</span>
@@ -2406,6 +2350,8 @@ payment.</p>
         <span class='type'>(<tt>Integer</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>1000</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
@@ -2422,11 +2368,12 @@ payment.</p>
         <span class='type'>(<tt>Boolean</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>false</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>return a more complex Hash of pending block information (default is
-<code>false</code>)</p>
+<p>return a more complex Hash of pending block information (default is <code>false</code>)</p>
 </div>
       
     </li>
@@ -2439,13 +2386,12 @@ payment.</p>
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -2546,14 +2492,11 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
     
 <p>Receives a pending payment into an account in the wallet.</p>
 
-<p>When called with no <code>block</code> argument, the latest pending payment
-for the account will be received.</p>
+<p>When called with no <code>block</code> argument, the latest pending payment for the account will be received.</p>
 
-<p>Returns a <em>receive</em> block hash id if a receive was successful, or
-<code>false</code> if there were no pending payments to receive.</p>
+<p>Returns a <em>receive</em> block hash id if a receive was successful, or <code>false</code> if there were no pending payments to receive.</p>
 
-<p>You can receive a specific pending block if you know it by passing the
-block has in as an argument.</p>
+<p>You can receive a specific pending block if you know it by passing the block has in as an argument.</p>
 
 <h4 id="label-Examples-3A">Examples:</h4>
 
@@ -2597,8 +2540,7 @@ block has in as an argument.</p>
       
         &mdash;
         <div class='inline'>
-<p>optional block id of pending payment. If not provided, the latest pending
-payment will be received</p>
+<p>optional block id of pending payment. If not provided, the latest pending payment will be received</p>
 </div>
       
     </li>
@@ -2675,9 +2617,7 @@ payment will be received</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Restores a previously created wallet by its seed. A new wallet will be
-created on your node (with a new wallet id) and will have its seed set to
-the given seed.</p>
+<p>Restores a previously created wallet by its seed. A new wallet will be created on your node (with a new wallet id) and will have its seed set to the given seed.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -2714,6 +2654,8 @@ the given seed.</p>
       
         <span class='type'>(<tt>Integer</tt>)</span>
       
+      
+        <em class="default">(defaults to: <tt>0</tt>)</em>
       
       
         &mdash;
@@ -2874,9 +2816,9 @@ the given seed.</p>
 </div>
 
       <div id="footer">
-  Generated on Mon Sep 16 06:30:35 2019 by
+  Generated on Fri Mar 26 12:47:24 2021 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.5.3).
+  0.9.24 (ruby-3.0.0).
 </div>
 
     </div>

--- a/docs/2.5.0/Nanook/WalletAccount.html
+++ b/docs/2.5.0/Nanook/WalletAccount.html
@@ -10,11 +10,11 @@
   
 </title>
 
-  <link rel="stylesheet" href="../css/style.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/style.css" type="text/css" />
 
-  <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/common.css" type="text/css" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = "Nanook::WalletAccount";
   relpath = '../';
 </script>
@@ -107,8 +107,7 @@
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
     
-<p>The <code>Nanook::WalletAccount</code> class lets you manage your nano
-accounts, including paying and receiving payment.</p>
+<p>The <code>Nanook::WalletAccount</code> class lets you manage your nano accounts, including paying and receiving payment.</p>
 
 <h3 id="label-Initializing">Initializing</h3>
 
@@ -258,8 +257,7 @@ accounts, including paying and receiving payment.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Information about this accounts that have set this account as their
-representative.</p>
+<p>Information about this accounts that have set this account as their representative.</p>
 </div></span>
   
 </li>
@@ -453,8 +451,7 @@ representative.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>The last modified time of the account in the time zone of your nano node
-(usually UTC).</p>
+<p>The last modified time of the account in the time zone of your nano node (usually UTC).</p>
 </div></span>
   
 </li>
@@ -478,8 +475,7 @@ representative.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Information about the given account as well as other accounts up the
-ledger.</p>
+<p>Information about the given account as well as other accounts up the ledger.</p>
 </div></span>
   
 </li>
@@ -527,8 +523,7 @@ ledger.</p>
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Information about pending blocks (payments) that are waiting to be received
-by the account.</p>
+<p>Information about pending blocks (payments) that are waiting to be received by the account.</p>
 </div></span>
   
 </li>
@@ -649,7 +644,7 @@ by the account.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns a new instance of WalletAccount</p>
+<p>Returns a new instance of WalletAccount.</p>
 
 
   </div>
@@ -691,9 +686,9 @@ by the account.</p>
   <span class='ivar'>@account</span> <span class='op'>=</span> <span class='id identifier rubyid_account'>account</span>
   <span class='ivar'>@nanook_account_instance</span> <span class='op'>=</span> <span class='kw'>nil</span>
 
-  <span class='kw'>unless</span> <span class='ivar'>@account</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span>
-    <span class='comment'># Wallet must contain the account
-</span>    <span class='kw'>unless</span> <span class='const'><span class='object_link'><a href="../Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Wallet.html" title="Nanook::Wallet (class)">Wallet</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Wallet.html#initialize-instance_method" title="Nanook::Wallet#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='ivar'>@rpc</span><span class='comma'>,</span> <span class='ivar'>@wallet</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_contains?'><span class='object_link'><a href="Wallet.html#contains%3F-instance_method" title="Nanook::Wallet#contains? (method)">contains?</a></span></span><span class='lparen'>(</span><span class='ivar'>@account</span><span class='rparen'>)</span>
+  <span class='kw'>unless</span> <span class='ivar'>@account</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span>    <span class='comment'># Wallet must contain the account
+</span>
+    <span class='kw'>unless</span> <span class='const'><span class='object_link'><a href="../Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Wallet.html" title="Nanook::Wallet (class)">Wallet</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Wallet.html#initialize-instance_method" title="Nanook::Wallet#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='ivar'>@rpc</span><span class='comma'>,</span> <span class='ivar'>@wallet</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_contains?'><span class='object_link'><a href="Wallet.html#contains%3F-instance_method" title="Nanook::Wallet#contains? (method)">contains?</a></span></span><span class='lparen'>(</span><span class='ivar'>@account</span><span class='rparen'>)</span>
       <span class='id identifier rubyid_raise'>raise</span> <span class='const'>ArgumentError</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Account does not exist in wallet. Account: </span><span class='embexpr_beg'>#{</span><span class='ivar'>@account</span><span class='embexpr_end'>}</span><span class='tstring_content'>, wallet: </span><span class='embexpr_beg'>#{</span><span class='ivar'>@wallet</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
     <span class='kw'>end</span>
 
@@ -727,8 +722,7 @@ by the account.</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>The account&#39;s balance, including pending (unreceived payments). To
-receive a pending amount see <span class='object_link'><a href="#receive-instance_method" title="Nanook::WalletAccount#receive (method)">#receive</a></span>.</p>
+<p>The account&#39;s balance, including pending (unreceived payments). To receive a pending amount see <span class='object_link'><a href="#receive-instance_method" title="Nanook::WalletAccount#receive (method)">#receive</a></span>.</p>
 
 <h4 id="label-Examples-3A">Examples:</h4>
 
@@ -771,13 +765,12 @@ receive a pending amount see <span class='object_link'><a href="#receive-instanc
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -845,7 +838,7 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns number of blocks for this account</p>
+<p>Returns number of blocks for this account.</p>
 
 
   </div>
@@ -902,16 +895,11 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
     
 <p>Sets the representative for the account.</p>
 
-<p>A representative is an account that will vote on your account&#39;s behalf
-on the nano network if your account is offline and there is a fork of the
-network that requires voting on.</p>
+<p>A representative is an account that will vote on your account&#39;s behalf on the nano network if your account is offline and there is a fork of the network that requires voting on.</p>
 
-<p>Returns the <em>change block</em> that was broadcast to the nano network.
-The block contains the information about the representative change for your
-account.</p>
+<p>Returns the <em>change block</em> that was broadcast to the nano network. The block contains the information about the representative change for your account.</p>
 
-<p>Also see <span class='object_link'><a href="Wallet.html#change_default_representative-instance_method" title="Nanook::Wallet#change_default_representative (method)">Nanook::Wallet#change_default_representative</a></span> for how to set a
-default representative for all new accounts created in a wallet.</p>
+<p>Also see <span class='object_link'><a href="Wallet.html#change_default_representative-instance_method" title="Nanook::Wallet#change_default_representative (method)">Nanook::Wallet#change_default_representative</a></span> for how to set a default representative for all new accounts created in a wallet.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -936,8 +924,7 @@ default representative for all new accounts created in a wallet.</p>
       
         &mdash;
         <div class='inline'>
-<p>the id of the representative account to set as this account&#39;s
-representative</p>
+<p>the id of the representative account to set as this account&#39;s representative</p>
 </div>
       
     </li>
@@ -1083,8 +1070,7 @@ representative</p>
       
         &mdash;
         <div class='inline'>
-<p>returns an Array of <span class='object_link'><a href="" title="Nanook::WalletAccount (class)">Nanook::WalletAccount</a></span> if method was called with
-argument <code>n</code> &gt;  1</p>
+<p>returns an Array of <span class='object_link'><a href="" title="Nanook::WalletAccount (class)">Nanook::WalletAccount</a></span> if method was called with argument <code>n</code> &gt;  1</p>
 </div>
       
     </li>
@@ -1162,8 +1148,7 @@ argument <code>n</code> &gt;  1</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Information about this accounts that have set this account as their
-representative.</p>
+<p>Information about this accounts that have set this account as their representative.</p>
 
 <h3 id="label-Example-3A">Example:</h3>
 
@@ -1193,13 +1178,12 @@ representative.</p>
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -1324,14 +1308,9 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
     
 <p>Returns true if the account has an <em>open</em> block.</p>
 
-<p>An open block gets published when an account receives a payment for the
-first time.</p>
+<p>An open block gets published when an account receives a payment for the first time.</p>
 
-<p>The reliability of this check depends on the node host having synchronized
-itself with most of the blocks on the nano network, otherwise you may get
-<code>false</code> when the account does exist. You can check if a
-node&#39;s  synchronization is particular low using
-<span class='object_link'><a href="Node.html#sync_progress-instance_method" title="Nanook::Node#sync_progress (method)">Node#sync_progress</a></span>.</p>
+<p>The reliability of this check depends on the node host having synchronized itself with most of the blocks on the nano network, otherwise you may get <code>false</code> when the account does exist. You can check if a node&#39;s  synchronization is particular low using <span class='object_link'><a href="Node.html#sync_progress-instance_method" title="Nanook::Node#sync_progress (method)">Node#sync_progress</a></span>.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1427,6 +1406,8 @@ node&#39;s  synchronization is particular low using
         <span class='type'>(<tt>Integer</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>1000</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
@@ -1443,13 +1424,12 @@ node&#39;s  synchronization is particular low using
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -1621,11 +1601,12 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
         <span class='type'>(<tt>Boolean</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>false</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>(default is false). When <code>true</code>, four additional calls are made
-to the RPC to return more information</p>
+<p>(default is false). When <code>true</code>, four additional calls are made to the RPC to return more information</p>
 </div>
       
     </li>
@@ -1638,13 +1619,12 @@ to the RPC to return more information</p>
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -1672,8 +1652,7 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
 <p>The latest block hash</p>
 </dd><dt><code>open_block</code>
 <dd>
-<p>The first block in every account&#39;s blockchain. When this block was
-published the account was officially open</p>
+<p>The first block in every account&#39;s blockchain. When this block was published the account was officially open</p>
 </dd><dt><code>representative_block</code>
 <dd>
 <p>The block that named the representative for the account</p>
@@ -1688,9 +1667,7 @@ published the account was officially open</p>
 <p>Number of blocks in the account&#39;s blockchain</p>
 </dd></dl>
 
-<p>When <code>detailed: true</code> is passed as an argument, this method
-makes four additional calls to the RPC to return more information about an
-account:</p>
+<p>When <code>detailed: true</code> is passed as an argument, this method makes four additional calls to the RPC to return more information about an account:</p>
 <dl class="rdoc-list label-list"><dt><code>weight</code>
 <dd>
 <p>See <span class='object_link'><a href="#weight-instance_method" title="Nanook::WalletAccount#weight (method)">#weight</a></span></p>
@@ -1791,8 +1768,7 @@ account:</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>The last modified time of the account in the time zone of your nano node
-(usually UTC).</p>
+<p>The last modified time of the account in the time zone of your nano node (usually UTC).</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1816,8 +1792,7 @@ account:</p>
       
         &mdash;
         <div class='inline'>
-<p>last modified time of the account in the time zone of your nano node
-(usually UTC).</p>
+<p>last modified time of the account in the time zone of your nano node (usually UTC).</p>
 </div>
       
     </li>
@@ -1853,9 +1828,7 @@ account:</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Information about the given account as well as other accounts up the
-ledger. The number of accounts returned is determined by the
-<code>limit:</code> argument.</p>
+<p>Information about the given account as well as other accounts up the ledger. The number of accounts returned is determined by the <code>limit:</code> argument.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -1892,6 +1865,8 @@ ledger. The number of accounts returned is determined by the
         <span class='type'>(<tt>Integer</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>1</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
@@ -1907,6 +1882,8 @@ ledger. The number of accounts returned is determined by the
       
         <span class='type'>(<tt>Time</tt>)</span>
       
+      
+        <em class="default">(defaults to: <tt>nil</tt>)</em>
       
       
         &mdash;
@@ -1924,13 +1901,12 @@ ledger. The number of accounts returned is determined by the
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -1980,17 +1956,11 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Makes a payment from this account to another account on the nano network.
-Returns a <em>send</em> block hash if successful, or a <span class='object_link'><a href="Error.html" title="Nanook::Error (class)">Error</a></span> if
-unsuccessful.</p>
+<p>Makes a payment from this account to another account on the nano network. Returns a <em>send</em> block hash if successful, or a <span class='object_link'><a href="Error.html" title="Nanook::Error (class)">Error</a></span> if unsuccessful.</p>
 
-<p>Note, there may be a delay in receiving a response due to Proof of Work
-being done. From the <a
-href="https://docs.nano.org/commands/rpc-protocol/#send">Nano RPC</a>:</p>
+<p>Note, there may be a delay in receiving a response due to Proof of Work being done. From the <a href="https://docs.nano.org/commands/rpc-protocol/#send">Nano RPC</a>:</p>
 
-<p><em>Proof of Work is precomputed for one transaction in the background. If
-it has been a while since your last transaction it will send instantly, the
-next one will need to wait for Proof of Work to be generated.</em></p>
+<p><em>Proof of Work is precomputed for one transaction in the background. If it has been a while since your last transaction it will send instantly, the next one will need to wait for Proof of Work to be generated.</em></p>
 
 <h4 id="label-Examples-3A">Examples:</h4>
 
@@ -2043,9 +2013,7 @@ next one will need to wait for Proof of Work to be generated.</em></p>
       
         &mdash;
         <div class='inline'>
-<p>must be unique per payment. It serves an important purpose; it allows you
-to make the same call multiple times with the same <code>id</code> and be
-reassured that you will only ever send this nano payment once</p>
+<p>must be unique per payment. It serves an important purpose; it allows you to make the same call multiple times with the same <code>id</code> and be reassured that you will only ever send this nano payment once</p>
 </div>
       
     </li>
@@ -2058,13 +2026,12 @@ reassured that you will only ever send this nano payment once</p>
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook::default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -2205,16 +2172,13 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Information about pending blocks (payments) that are waiting to be received
-by the account.</p>
+<p>Information about pending blocks (payments) that are waiting to be received by the account.</p>
 
-<p>See also the <span class='object_link'><a href="#receive-instance_method" title="Nanook::WalletAccount#receive (method)">#receive</a></span> method for how to receive a
-pending payment.</p>
+<p>See also the <span class='object_link'><a href="#receive-instance_method" title="Nanook::WalletAccount#receive (method)">#receive</a></span> method for how to receive a pending payment.</p>
 
 <p>The default response is an Array of block ids.</p>
 
-<p>With the <code>detailed:</code> argument, the method returns an Array of
-Hashes, which contain the source account id, amount pending and block id.</p>
+<p>With the <code>detailed:</code> argument, the method returns an Array of Hashes, which contain the source account id, amount pending and block id.</p>
 
 <h4 id="label-Examples-3A">Examples:</h4>
 
@@ -2253,6 +2217,8 @@ Hashes, which contain the source account id, amount pending and block id.</p>
         <span class='type'>(<tt>Integer</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>1000</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
@@ -2269,11 +2235,12 @@ Hashes, which contain the source account id, amount pending and block id.</p>
         <span class='type'>(<tt>Boolean</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>false</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>return a more complex Hash of pending block information (default is
-<code>false</code>)</p>
+<p>return a more complex Hash of pending block information (default is <code>false</code>)</p>
 </div>
       
     </li>
@@ -2286,13 +2253,12 @@ Hashes, which contain the source account id, amount pending and block id.</p>
         <span class='type'>(<tt>Symbol</tt>)</span>
       
       
+        <em class="default">(defaults to: <tt>Nanook.default_unit</tt>)</em>
+      
       
         &mdash;
         <div class='inline'>
-<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>.
-Represents the unit that the balances will be returned in. Note: this
-method interprets <code>:nano</code> as NANO, which is technically Mnano.
-See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" title="What are Nano&amp;#39;s Units">What are Nano&#39;s Units</a></p>
+<p>default is <span class='object_link'><a href="../Nanook.html#default_unit-class_method" title="Nanook.default_unit (method)">Nanook.default_unit</a></span>. Must be one of <span class='object_link'><a href="../Nanook.html#UNITS-constant" title="Nanook::UNITS (constant)">UNITS</a></span>. Represents the unit that the balances will be returned in. Note: this method interprets <code>:nano</code> as NANO, which is technically Mnano. See <a href="https://nano.org/en/faq#what-are-nano-units" target="_parent" title="- What are Nano&amp;#39;s Units">- What are Nano&#39;s Units</a></p>
 </div>
       
     </li>
@@ -2413,14 +2379,11 @@ See <a href="https://nano.org/en/faq#what-are-nano-units-" target="_parent" titl
     
 <p>Receives a pending payment for this account.</p>
 
-<p>When called with no <code>block</code> argument, the latest pending payment
-for the account will be received.</p>
+<p>When called with no <code>block</code> argument, the latest pending payment for the account will be received.</p>
 
-<p>Returns a <em>receive</em> block id if a receive was successful, or
-<code>false</code> if there were no pending payments to receive.</p>
+<p>Returns a <em>receive</em> block id if a receive was successful, or <code>false</code> if there were no pending payments to receive.</p>
 
-<p>You can receive a specific pending block if you know it by passing the
-block in as an argument.</p>
+<p>You can receive a specific pending block if you know it by passing the block in as an argument.</p>
 
 <h4 id="label-Examples-3A">Examples:</h4>
 
@@ -2448,8 +2411,7 @@ block in as an argument.</p>
       
         &mdash;
         <div class='inline'>
-<p>optional block id of pending payment. If not provided, the latest pending
-payment will be received</p>
+<p>optional block id of pending payment. If not provided, the latest pending payment will be received</p>
 </div>
       
     </li>
@@ -2530,8 +2492,7 @@ payment will be received</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>The representative account id for the account. Representatives are accounts
-that cast votes in the case of a fork in the network.</p>
+<p>The representative account id for the account. Representatives are accounts that cast votes in the case of a fork in the network.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -2593,9 +2554,7 @@ that cast votes in the case of a fork in the network.</p>
     
 <p>The account&#39;s weight.</p>
 
-<p>Weight is determined by the account&#39;s balance, and represents the
-voting weight that account has on the network. Only accounts with greater
-than 256 weight can vote.</p>
+<p>Weight is determined by the account&#39;s balance, and represents the voting weight that account has on the network. Only accounts with greater than 256 weight can vote.</p>
 
 <h4 id="label-Example-3A">Example:</h4>
 
@@ -2648,9 +2607,9 @@ than 256 weight can vote.</p>
 </div>
 
       <div id="footer">
-  Generated on Mon Sep 16 06:30:35 2019 by
+  Generated on Fri Mar 26 12:47:25 2021 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.5.3).
+  0.9.24 (ruby-3.0.0).
 </div>
 
     </div>

--- a/docs/2.5.0/Nanook/WorkPeer.html
+++ b/docs/2.5.0/Nanook/WorkPeer.html
@@ -10,11 +10,11 @@
   
 </title>
 
-  <link rel="stylesheet" href="../css/style.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/style.css" type="text/css" />
 
-  <link rel="stylesheet" href="../css/common.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="../css/common.css" type="text/css" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = "Nanook::WorkPeer";
   relpath = '../';
 </script>
@@ -246,7 +246,7 @@
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns a new instance of WorkPeer</p>
+<p>Returns a new instance of WorkPeer.</p>
 
 
   </div>
@@ -407,9 +407,9 @@
 </div>
 
       <div id="footer">
-  Generated on Mon Sep 16 06:30:35 2019 by
+  Generated on Fri Mar 26 12:47:25 2021 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.5.3).
+  0.9.24 (ruby-3.0.0).
 </div>
 
     </div>

--- a/docs/2.5.0/_index.html
+++ b/docs/2.5.0/_index.html
@@ -8,11 +8,11 @@
   
 </title>
 
-  <link rel="stylesheet" href="css/style.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="css/style.css" type="text/css" />
 
-  <link rel="stylesheet" href="css/common.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="css/common.css" type="text/css" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = null;
   relpath = '';
 </script>
@@ -226,9 +226,9 @@
 </div>
 
       <div id="footer">
-  Generated on Mon Sep 16 06:30:33 2019 by
+  Generated on Fri Mar 26 12:47:22 2021 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.5.3).
+  0.9.24 (ruby-3.0.0).
 </div>
 
     </div>

--- a/docs/2.5.0/class_list.html
+++ b/docs/2.5.0/class_list.html
@@ -4,9 +4,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="utf-8" />
     
-      <link rel="stylesheet" href="css/full_list.css" type="text/css" media="screen" charset="utf-8" />
+      <link rel="stylesheet" href="css/full_list.css" type="text/css" media="screen" />
     
-      <link rel="stylesheet" href="css/common.css" type="text/css" media="screen" charset="utf-8" />
+      <link rel="stylesheet" href="css/common.css" type="text/css" media="screen" />
     
 
     

--- a/docs/2.5.0/css/style.css
+++ b/docs/2.5.0/css/style.css
@@ -245,6 +245,7 @@ ul.toplevel { list-style: none; padding-left: 0; font-size: 1.1em; }
 
 dl.constants { margin-left: 10px; }
 dl.constants dt { font-weight: bold; font-size: 1.1em; margin-bottom: 5px; }
+dl.constants.compact dt { display: inline-block; font-weight: normal }
 dl.constants dd { width: 75%; white-space: pre; font-family: monospace; margin-bottom: 18px; }
 dl.constants .docstring .note:first-child { margin-top: 5px; }
 
@@ -326,13 +327,9 @@ ul.summary a, ul.summary a:visited {
   text-decoration: none; font-size: 1.1em;
 }
 ul.summary li { margin-bottom: 5px; }
-.summary .summary_signature {
-  padding: 4px 8px;
-  background: #f8f8f8;
-  border: 1px solid #f0f0f0;
-  border-radius: 5px;
-}
+.summary_signature { padding: 4px 8px; background: #f8f8f8; border: 1px solid #f0f0f0; border-radius: 5px; }
 .summary_signature:hover { background: #CFEBFF; border-color: #A4CCDA; cursor: pointer; }
+.summary_signature.deprecated { background: #ffe5e5; border-color: #e9dada; }
 ul.summary.compact li { display: inline-block; margin: 0px 5px 0px 0px; line-height: 2.6em;}
 ul.summary.compact .summary_signature { padding: 5px 7px; padding-right: 4px; }
 #content .summary_signature:hover a,
@@ -425,8 +422,8 @@ li.r2 { background: #fafafa; }
 #toc ol { padding-left: 1.8em; }
 #toc li { font-size: 1.1em; line-height: 1.7em; }
 #toc > ol > li { font-size: 1.1em; font-weight: bold; }
-#toc ol > ol { font-size: 0.9em; }
-#toc ol ol > ol { padding-left: 2.3em; }
+#toc ol > li > ol { font-size: 0.9em; }
+#toc ol ol > li > ol { padding-left: 2.3em; }
 #toc ol + li { margin-top: 0.3em; }
 #toc.hidden { padding: 10px; background: #fefefe; box-shadow: none; }
 #toc.hidden:hover { background: #fafafa; }
@@ -485,7 +482,7 @@ pre.code .rubyid_nth_ref { color: #6D79DE; }
 pre.code .regexp, .dregexp { color: #036A07; }
 pre.code a { border-bottom: 1px dotted #bbf; }
 /* inline code */
-p > code {
+*:not(pre) > code {
 	padding: 1px 3px 1px 3px;
 	border: 1px solid #E1E1E8;
 	background: #F7F7F9;

--- a/docs/2.5.0/file.README.html
+++ b/docs/2.5.0/file.README.html
@@ -10,11 +10,11 @@
   
 </title>
 
-  <link rel="stylesheet" href="css/style.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="css/style.css" type="text/css" />
 
-  <link rel="stylesheet" href="css/common.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="css/common.css" type="text/css" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = "README";
   relpath = '';
 </script>
@@ -60,16 +60,9 @@
       <div id="content"><div id='filecontents'>
 <h1 id="label-Nanook">Nanook</h1>
 
-<p>This is a Ruby library for managing a <a href="https://nano.org/">nano
-currency</a> node, including making and receiving payments, using the <a
-href="https://docs.nano.org/commands/rpc-protocol">nano RPC protocol</a>.
-Nano is a fee-less, fast, environmentally-friendly cryptocurrency. It&#39;s
-awesome. See <a href="https://nano.org/">nano.org</a>.</p>
+<p>This is a Ruby library for managing a <a href="https://nano.org/">nano currency</a> node, including making and receiving payments, using the <a href="https://docs.nano.org/commands/rpc-protocol">nano RPC protocol</a>. Nano is a fee-less, fast, environmentally-friendly cryptocurrency. It&#39;s awesome. See <a href="https://nano.org/">nano.org</a>.</p>
 
-<p><a href="https://badge.fury.io/rb/nanook"><img
-src="https://badge.fury.io/rb/nanook.svg"></a> <a
-href="https://circleci.com/gh/lukes/nanook/tree/master"><img
-src="https://circleci.com/gh/lukes/nanook/tree/master.svg?style=shield"></a></p>
+<p><a href="https://badge.fury.io/rb/nanook"><img src="https://badge.fury.io/rb/nanook.svg"></a> <a href="https://circleci.com/gh/lukes/nanook/tree/master"><img src="https://circleci.com/gh/lukes/nanook/tree/master.svg?style=shield"></a></p>
 
 <h2 id="label-Installation">Installation</h2>
 
@@ -135,34 +128,21 @@ src="https://circleci.com/gh/lukes/nanook/tree/master.svg?style=shield"></a></p>
 <span class='id identifier rubyid_wallet'>wallet</span><span class='period'>.</span><span class='id identifier rubyid_pay'>pay</span><span class='lparen'>(</span><span class='label'>from:</span> <span class='id identifier rubyid_your_account_id'>your_account_id</span><span class='comma'>,</span> <span class='label'>to:</span> <span class='id identifier rubyid_recipient_account_id'>recipient_account_id</span><span class='comma'>,</span> <span class='label'>amount:</span> <span class='float'>0.2</span><span class='comma'>,</span> <span class='label'>id:</span> <span class='id identifier rubyid_unique_id'>unique_id</span><span class='rparen'>)</span>
 </code></pre>
 
-<p>The <code>id</code> can be any string and needs to be unique per payment.
-It serves an important purpose; it allows you to make this call multiple
-times with the same <code>id</code> and be reassured that you will only
-ever send that nano payment once. From the <a
-href="https://docs.nano.org/commands/rpc-protocol/#send">Nano RPC</a>:</p>
+<p>The <code>id</code> can be any string and needs to be unique per payment. It serves an important purpose; it allows you to make this call multiple times with the same <code>id</code> and be reassured that you will only ever send that nano payment once. From the <a href="https://docs.nano.org/commands/rpc-protocol/#send">Nano RPC</a>:</p>
 
 <blockquote>
-<p>You can (and should) specify a unique id for each spend to provide
-idempotency. That means that if you [make the payment call] two times with
-the same id, the second request won&#39;t send any additional Nano.</p>
+<p>You can (and should) specify a unique id for each spend to provide idempotency. That means that if you [make the payment call] two times with the same id, the second request won&#39;t send any additional Nano.</p>
 </blockquote>
 
-<p>The unit of the <code>amount</code> is NANO (which is currently technically
-Mnano — see <a href="https://nano.org/en/faq#what-are-nano-units-">What are
-Nano’s Units</a>). You can pass an amount of raw instead by adding the
-<code>unit: :raw</code> argument:</p>
+<p>The unit of the <code>amount</code> is NANO (which is currently technically Mnano — see <a href="https://nano.org/en/faq#what-are-nano-units-">What are Nano’s Units</a>). You can pass an amount of raw instead by adding the <code>unit: :raw</code> argument:</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_account'>account</span><span class='period'>.</span><span class='id identifier rubyid_pay'>pay</span><span class='lparen'>(</span><span class='label'>to:</span> <span class='id identifier rubyid_recipient_account_id'>recipient_account_id</span><span class='comma'>,</span> <span class='label'>amount:</span> <span class='int'>999</span><span class='comma'>,</span> <span class='label'>unit:</span> <span class='symbol'>:raw</span><span class='comma'>,</span> <span class='label'>id:</span> <span class='id identifier rubyid_unique_id'>unique_id</span><span class='rparen'>)</span>
 </code></pre>
 
-<p>Note, there may be a delay in receiving a response due to Proof of Work
-being done. From the <a
-href="https://docs.nano.org/commands/rpc-protocol/#send">Nano RPC</a>:</p>
+<p>Note, there may be a delay in receiving a response due to Proof of Work being done. From the <a href="https://docs.nano.org/commands/rpc-protocol/#send">Nano RPC</a>:</p>
 
 <blockquote>
-<p>Proof of Work is precomputed for one transaction in the background. If it
-has been a while since your last transaction it will send instantly, the
-next one will need to wait for Proof of Work to be generated.</p>
+<p>Proof of Work is precomputed for one transaction in the background. If it has been a while since your last transaction it will send instantly, the next one will need to wait for Proof of Work to be generated.</p>
 </blockquote>
 
 <h3 id="label-Receiving+a+payment">Receiving a payment</h3>
@@ -178,13 +158,9 @@ next one will need to wait for Proof of Work to be generated.</p>
 <span class='id identifier rubyid_wallet'>wallet</span><span class='period'>.</span><span class='id identifier rubyid_receive'>receive</span><span class='lparen'>(</span><span class='label'>into:</span> <span class='id identifier rubyid_account_id'>account_id</span><span class='rparen'>)</span>
 </code></pre>
 
-<p>The <code>receive</code> method when called as above will receive the
-latest pending payment for an account in a wallet. It will either return a
-block hash if a payment was received, or <code>false</code> if there were
-no pending payments to receive.</p>
+<p>The <code>receive</code> method when called as above will receive the latest pending payment for an account in a wallet. It will either return a block hash if a payment was received, or <code>false</code> if there were no pending payments to receive.</p>
 
-<p>You can also receive a specific pending block if you know it (you may have
-discovered it through calling <code>account.pending</code> for example):</p>
+<p>You can also receive a specific pending block if you know it (you may have discovered it through calling <code>account.pending</code> for example):</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_account'>account</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Nanook.html#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span><span class='period'>.</span><span class='id identifier rubyid_wallet'><span class='object_link'><a href="Nanook.html#wallet-instance_method" title="Nanook#wallet (method)">wallet</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_wallet_id'>wallet_id</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_account'><span class='object_link'><a href="Nanook/Wallet.html#account-instance_method" title="Nanook::Wallet#account (method)">account</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_account_id'>account_id</span><span class='rparen'>)</span>
 <span class='id identifier rubyid_account'>account</span><span class='period'>.</span><span class='id identifier rubyid_receive'>receive</span><span class='lparen'>(</span><span class='id identifier rubyid_block_id'>block_id</span><span class='rparen'>)</span>
@@ -197,18 +173,11 @@ discovered it through calling <code>account.pending</code> for example):</p>
 
 <h2 id="label-All+commands">All commands</h2>
 
-<p>Below is a quick reference list of commands. See the <a
-href="https://lukes.github.io/nanook/2.5.0/">full Nanook documentation</a>
-for a searchable detailed description of every class and method, what the
-arguments mean, and example responses (Tip: the classes are listed under
-the “<strong>Nanook</strong> &lt; Object” item in the sidebar).</p>
+<p>Below is a quick reference list of commands. See the <a href="https://lukes.github.io/nanook/2.5.0/">full Nanook documentation</a> for a searchable detailed description of every class and method, what the arguments mean, and example responses (Tip: the classes are listed under the “<strong>Nanook</strong> &lt; Object” item in the sidebar).</p>
 
 <h3 id="label-Wallets">Wallets</h3>
 
-<p>See the <a
-href="https://lukes.github.io/nanook/2.5.0/Nanook/Wallet.html">full
-documentation for Nanook::Wallet</a> for a detailed description of each
-method and example responses.</p>
+<p>See the <a href="https://lukes.github.io/nanook/2.5.0/Nanook/Wallet.html">full documentation for Nanook::Wallet</a> for a detailed description of each method and example responses.</p>
 
 <h4 id="label-Create+wallet-3A">Create wallet:</h4>
 
@@ -220,8 +189,7 @@ method and example responses.</p>
 <pre class="code ruby"><code class="ruby"><span class='const'><span class='object_link'><a href="Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Nanook.html#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span><span class='period'>.</span><span class='id identifier rubyid_wallet'><span class='object_link'><a href="Nanook.html#wallet-instance_method" title="Nanook#wallet (method)">wallet</a></span></span><span class='period'>.</span><span class='id identifier rubyid_restore'><span class='object_link'><a href="Nanook/Wallet.html#restore-instance_method" title="Nanook::Wallet#restore (method)">restore</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_seed'>seed</span><span class='rparen'>)</span>
 </code></pre>
 
-<p>Optionally also restore the wallet&#39;s accounts: <code>ruby
-Nanook.new.wallet.restore(seed, accounts: 2) </code></p>
+<p>Optionally also restore the wallet&#39;s accounts: <code>ruby Nanook.new.wallet.restore(seed, accounts: 2) </code></p>
 
 <h4 id="label-Working+with+a+single+wallet-3A">Working with a single wallet:</h4>
 
@@ -271,10 +239,7 @@ Nanook.new.wallet.restore(seed, accounts: 2) </code></p>
 
 <h4 id="label-Working+with+a+single+account-3A">Working with a single account:</h4>
 
-<p>See the <a
-href="https://lukes.github.io/nanook/2.5.0/Nanook/WalletAccount.html">full
-documentation for Nanook::WalletAccount</a> for a detailed description of
-each method and example responses.</p>
+<p>See the <a href="https://lukes.github.io/nanook/2.5.0/Nanook/WalletAccount.html">full documentation for Nanook::WalletAccount</a> for a detailed description of each method and example responses.</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_account'>account</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Nanook.html#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span><span class='period'>.</span><span class='id identifier rubyid_wallet'><span class='object_link'><a href="Nanook.html#wallet-instance_method" title="Nanook#wallet (method)">wallet</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_wallet_id'>wallet_id</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_account'><span class='object_link'><a href="Nanook/Wallet.html#account-instance_method" title="Nanook::Wallet#account (method)">account</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_account_id'>account_id</span><span class='rparen'>)</span>
 
@@ -313,10 +278,7 @@ each method and example responses.</p>
 
 <h4 id="label-Working+with+any+account+-28not+necessarily+in+your+wallet-29-3A">Working with any account (not necessarily in your wallet):</h4>
 
-<p>See the <a
-href="https://lukes.github.io/nanook/2.5.0/Nanook/Account.html">full
-documentation for Nanook::Account</a> for a detailed description of each
-method and example responses.</p>
+<p>See the <a href="https://lukes.github.io/nanook/2.5.0/Nanook/Account.html">full documentation for Nanook::Account</a> for a detailed description of each method and example responses.</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_account'>account</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Nanook.html#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span><span class='period'>.</span><span class='id identifier rubyid_account'><span class='object_link'><a href="Nanook.html#account-instance_method" title="Nanook#account (method)">account</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_account_id'>account_id</span><span class='rparen'>)</span>
 
@@ -348,10 +310,7 @@ method and example responses.</p>
 
 <h3 id="label-Blocks">Blocks</h3>
 
-<p>See the <a
-href="https://lukes.github.io/nanook/2.5.0/Nanook/Block.html">full
-documentation for Nanook::Block</a> for a detailed description of each
-method and example responses.</p>
+<p>See the <a href="https://lukes.github.io/nanook/2.5.0/Nanook/Block.html">full documentation for Nanook::Block</a> for a detailed description of each method and example responses.</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_block'>block</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Nanook.html#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span><span class='period'>.</span><span class='id identifier rubyid_block'><span class='object_link'><a href="Nanook.html#block-instance_method" title="Nanook#block (method)">block</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_block_id'>block_id</span><span class='rparen'>)</span>
 
@@ -382,10 +341,7 @@ method and example responses.</p>
 
 <h3 id="label-Managing+your+nano+node">Managing your nano node</h3>
 
-<p>See the <a
-href="https://lukes.github.io/nanook/2.5.0/Nanook/Node.html">full
-documentation for Nanook::Node</a> for a detailed description of each
-method and example responses.</p>
+<p>See the <a href="https://lukes.github.io/nanook/2.5.0/Nanook/Node.html">full documentation for Nanook::Node</a> for a detailed description of each method and example responses.</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_node'>node</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Nanook.html#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span><span class='period'>.</span><span class='id identifier rubyid_node'><span class='object_link'><a href="Nanook.html#node-instance_method" title="Nanook#node (method)">node</a></span></span>
 
@@ -438,23 +394,16 @@ method and example responses.</p>
 
 <h2 id="label-Nanook+Metal">Nanook Metal</h2>
 
-<p>You can do any call listed in the <a
-href="https://docs.nano.org/commands/rpc-protocol">Nano RPC</a> directly
-through the <code>rpc</code> method. The first argument should match the
-<code>action</code> of the RPC call, and then all remaining parameters are
-passed in as arguments.</p>
+<p>You can do any call listed in the <a href="https://docs.nano.org/commands/rpc-protocol">Nano RPC</a> directly through the <code>rpc</code> method. The first argument should match the <code>action</code> of the RPC call, and then all remaining parameters are passed in as arguments.</p>
 
-<p>E.g., the <a
-href="https://docs.nano.org/commands/rpc-protocol/#accounts_create">accounts_create
-command</a> can be called like this:</p>
+<p>E.g., the <a href="https://docs.nano.org/commands/rpc-protocol/#accounts_create">accounts_create command</a> can be called like this:</p>
 
 <pre class="code ruby"><code class="ruby"><span class='const'><span class='object_link'><a href="Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Nanook.html#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span><span class='period'>.</span><span class='id identifier rubyid_rpc'><span class='object_link'><a href="Nanook.html#rpc-instance_method" title="Nanook#rpc (method)">rpc</a></span></span><span class='period'>.</span><span class='id identifier rubyid_call'><span class='object_link'><a href="Nanook/Rpc.html#call-instance_method" title="Nanook::Rpc#call (method)">call</a></span></span><span class='lparen'>(</span><span class='symbol'>:accounts_create</span><span class='comma'>,</span> <span class='label'>wallet:</span> <span class='id identifier rubyid_wallet_id'>wallet_id</span><span class='comma'>,</span> <span class='label'>count:</span> <span class='int'>2</span><span class='rparen'>)</span>
 </code></pre>
 
 <h2 id="label-Contributing">Contributing</h2>
 
-<p>Bug reports and pull requests are welcome. Pull requests with passing tests
-are even better.</p>
+<p>Bug reports and pull requests are welcome. Pull requests with passing tests are even better.</p>
 
 <p>To run the test suite:</p>
 
@@ -468,26 +417,22 @@ are even better.</p>
 
 <h2 id="label-License">License</h2>
 
-<p>The gem is available as open source under the terms of the <a
-href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
+<p>The gem is available as open source under the terms of the <a href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
 
 <h2 id="label-Buy+me+a+nano+coffee">Buy me a nano coffee</h2>
 
-<p>This library is totally free to use, but feel free to send some nano <a
-href="https://www.nanode.co/account/nano_3c3ek3k8135f6e8qtfy8eruk9q3yzmpebes7btzncccdest8ymzhjmnr196j">my
-way</a> if you&#39;d like to!</p>
+<p>This library is totally free to use, but feel free to send some nano <a href="https://www.nanode.co/account/nano_3c3ek3k8135f6e8qtfy8eruk9q3yzmpebes7btzncccdest8ymzhjmnr196j">my way</a> if you&#39;d like to!</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_nano_3c3ek3k8135f6e8qtfy8eruk9q3yzmpebes7btzncccdest8ymzhjmnr196j'>nano_3c3ek3k8135f6e8qtfy8eruk9q3yzmpebes7btzncccdest8ymzhjmnr196j</span>
 </code></pre>
 
-<p><img
-src="https://raw.githubusercontent.com/lukes/nanook/master/img/qr.png"></p>
+<p><img src="https://raw.githubusercontent.com/lukes/nanook/master/img/qr.png"></p>
 </div></div>
 
       <div id="footer">
-  Generated on Mon Sep 16 06:30:33 2019 by
+  Generated on Fri Mar 26 12:47:23 2021 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.5.3).
+  0.9.24 (ruby-3.0.0).
 </div>
 
     </div>

--- a/docs/2.5.0/file_list.html
+++ b/docs/2.5.0/file_list.html
@@ -4,9 +4,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="utf-8" />
     
-      <link rel="stylesheet" href="css/full_list.css" type="text/css" media="screen" charset="utf-8" />
+      <link rel="stylesheet" href="css/full_list.css" type="text/css" media="screen" />
     
-      <link rel="stylesheet" href="css/common.css" type="text/css" media="screen" charset="utf-8" />
+      <link rel="stylesheet" href="css/common.css" type="text/css" media="screen" />
     
 
     

--- a/docs/2.5.0/frames.html
+++ b/docs/2.5.0/frames.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
 	<title>Nanook 2.5.0 Documentation</title>
 </head>
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   var match = unescape(window.location.hash).match(/^#!(.+)/);
   var name = match ? match[1] : 'index.html';
   name = name.replace(/^(\w+):\/\//, '').replace(/^\/\//, '');

--- a/docs/2.5.0/index.html
+++ b/docs/2.5.0/index.html
@@ -10,11 +10,11 @@
   
 </title>
 
-  <link rel="stylesheet" href="css/style.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="css/style.css" type="text/css" />
 
-  <link rel="stylesheet" href="css/common.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="css/common.css" type="text/css" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = "README";
   relpath = '';
 </script>
@@ -60,16 +60,9 @@
       <div id="content"><div id='filecontents'>
 <h1 id="label-Nanook">Nanook</h1>
 
-<p>This is a Ruby library for managing a <a href="https://nano.org/">nano
-currency</a> node, including making and receiving payments, using the <a
-href="https://docs.nano.org/commands/rpc-protocol">nano RPC protocol</a>.
-Nano is a fee-less, fast, environmentally-friendly cryptocurrency. It&#39;s
-awesome. See <a href="https://nano.org/">nano.org</a>.</p>
+<p>This is a Ruby library for managing a <a href="https://nano.org/">nano currency</a> node, including making and receiving payments, using the <a href="https://docs.nano.org/commands/rpc-protocol">nano RPC protocol</a>. Nano is a fee-less, fast, environmentally-friendly cryptocurrency. It&#39;s awesome. See <a href="https://nano.org/">nano.org</a>.</p>
 
-<p><a href="https://badge.fury.io/rb/nanook"><img
-src="https://badge.fury.io/rb/nanook.svg"></a> <a
-href="https://circleci.com/gh/lukes/nanook/tree/master"><img
-src="https://circleci.com/gh/lukes/nanook/tree/master.svg?style=shield"></a></p>
+<p><a href="https://badge.fury.io/rb/nanook"><img src="https://badge.fury.io/rb/nanook.svg"></a> <a href="https://circleci.com/gh/lukes/nanook/tree/master"><img src="https://circleci.com/gh/lukes/nanook/tree/master.svg?style=shield"></a></p>
 
 <h2 id="label-Installation">Installation</h2>
 
@@ -135,34 +128,21 @@ src="https://circleci.com/gh/lukes/nanook/tree/master.svg?style=shield"></a></p>
 <span class='id identifier rubyid_wallet'>wallet</span><span class='period'>.</span><span class='id identifier rubyid_pay'>pay</span><span class='lparen'>(</span><span class='label'>from:</span> <span class='id identifier rubyid_your_account_id'>your_account_id</span><span class='comma'>,</span> <span class='label'>to:</span> <span class='id identifier rubyid_recipient_account_id'>recipient_account_id</span><span class='comma'>,</span> <span class='label'>amount:</span> <span class='float'>0.2</span><span class='comma'>,</span> <span class='label'>id:</span> <span class='id identifier rubyid_unique_id'>unique_id</span><span class='rparen'>)</span>
 </code></pre>
 
-<p>The <code>id</code> can be any string and needs to be unique per payment.
-It serves an important purpose; it allows you to make this call multiple
-times with the same <code>id</code> and be reassured that you will only
-ever send that nano payment once. From the <a
-href="https://docs.nano.org/commands/rpc-protocol/#send">Nano RPC</a>:</p>
+<p>The <code>id</code> can be any string and needs to be unique per payment. It serves an important purpose; it allows you to make this call multiple times with the same <code>id</code> and be reassured that you will only ever send that nano payment once. From the <a href="https://docs.nano.org/commands/rpc-protocol/#send">Nano RPC</a>:</p>
 
 <blockquote>
-<p>You can (and should) specify a unique id for each spend to provide
-idempotency. That means that if you [make the payment call] two times with
-the same id, the second request won&#39;t send any additional Nano.</p>
+<p>You can (and should) specify a unique id for each spend to provide idempotency. That means that if you [make the payment call] two times with the same id, the second request won&#39;t send any additional Nano.</p>
 </blockquote>
 
-<p>The unit of the <code>amount</code> is NANO (which is currently technically
-Mnano — see <a href="https://nano.org/en/faq#what-are-nano-units-">What are
-Nano’s Units</a>). You can pass an amount of raw instead by adding the
-<code>unit: :raw</code> argument:</p>
+<p>The unit of the <code>amount</code> is NANO (which is currently technically Mnano — see <a href="https://nano.org/en/faq#what-are-nano-units-">What are Nano’s Units</a>). You can pass an amount of raw instead by adding the <code>unit: :raw</code> argument:</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_account'>account</span><span class='period'>.</span><span class='id identifier rubyid_pay'>pay</span><span class='lparen'>(</span><span class='label'>to:</span> <span class='id identifier rubyid_recipient_account_id'>recipient_account_id</span><span class='comma'>,</span> <span class='label'>amount:</span> <span class='int'>999</span><span class='comma'>,</span> <span class='label'>unit:</span> <span class='symbol'>:raw</span><span class='comma'>,</span> <span class='label'>id:</span> <span class='id identifier rubyid_unique_id'>unique_id</span><span class='rparen'>)</span>
 </code></pre>
 
-<p>Note, there may be a delay in receiving a response due to Proof of Work
-being done. From the <a
-href="https://docs.nano.org/commands/rpc-protocol/#send">Nano RPC</a>:</p>
+<p>Note, there may be a delay in receiving a response due to Proof of Work being done. From the <a href="https://docs.nano.org/commands/rpc-protocol/#send">Nano RPC</a>:</p>
 
 <blockquote>
-<p>Proof of Work is precomputed for one transaction in the background. If it
-has been a while since your last transaction it will send instantly, the
-next one will need to wait for Proof of Work to be generated.</p>
+<p>Proof of Work is precomputed for one transaction in the background. If it has been a while since your last transaction it will send instantly, the next one will need to wait for Proof of Work to be generated.</p>
 </blockquote>
 
 <h3 id="label-Receiving+a+payment">Receiving a payment</h3>
@@ -178,13 +158,9 @@ next one will need to wait for Proof of Work to be generated.</p>
 <span class='id identifier rubyid_wallet'>wallet</span><span class='period'>.</span><span class='id identifier rubyid_receive'>receive</span><span class='lparen'>(</span><span class='label'>into:</span> <span class='id identifier rubyid_account_id'>account_id</span><span class='rparen'>)</span>
 </code></pre>
 
-<p>The <code>receive</code> method when called as above will receive the
-latest pending payment for an account in a wallet. It will either return a
-block hash if a payment was received, or <code>false</code> if there were
-no pending payments to receive.</p>
+<p>The <code>receive</code> method when called as above will receive the latest pending payment for an account in a wallet. It will either return a block hash if a payment was received, or <code>false</code> if there were no pending payments to receive.</p>
 
-<p>You can also receive a specific pending block if you know it (you may have
-discovered it through calling <code>account.pending</code> for example):</p>
+<p>You can also receive a specific pending block if you know it (you may have discovered it through calling <code>account.pending</code> for example):</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_account'>account</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Nanook.html#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span><span class='period'>.</span><span class='id identifier rubyid_wallet'><span class='object_link'><a href="Nanook.html#wallet-instance_method" title="Nanook#wallet (method)">wallet</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_wallet_id'>wallet_id</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_account'><span class='object_link'><a href="Nanook/Wallet.html#account-instance_method" title="Nanook::Wallet#account (method)">account</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_account_id'>account_id</span><span class='rparen'>)</span>
 <span class='id identifier rubyid_account'>account</span><span class='period'>.</span><span class='id identifier rubyid_receive'>receive</span><span class='lparen'>(</span><span class='id identifier rubyid_block_id'>block_id</span><span class='rparen'>)</span>
@@ -197,18 +173,11 @@ discovered it through calling <code>account.pending</code> for example):</p>
 
 <h2 id="label-All+commands">All commands</h2>
 
-<p>Below is a quick reference list of commands. See the <a
-href="https://lukes.github.io/nanook/2.5.0/">full Nanook documentation</a>
-for a searchable detailed description of every class and method, what the
-arguments mean, and example responses (Tip: the classes are listed under
-the “<strong>Nanook</strong> &lt; Object” item in the sidebar).</p>
+<p>Below is a quick reference list of commands. See the <a href="https://lukes.github.io/nanook/2.5.0/">full Nanook documentation</a> for a searchable detailed description of every class and method, what the arguments mean, and example responses (Tip: the classes are listed under the “<strong>Nanook</strong> &lt; Object” item in the sidebar).</p>
 
 <h3 id="label-Wallets">Wallets</h3>
 
-<p>See the <a
-href="https://lukes.github.io/nanook/2.5.0/Nanook/Wallet.html">full
-documentation for Nanook::Wallet</a> for a detailed description of each
-method and example responses.</p>
+<p>See the <a href="https://lukes.github.io/nanook/2.5.0/Nanook/Wallet.html">full documentation for Nanook::Wallet</a> for a detailed description of each method and example responses.</p>
 
 <h4 id="label-Create+wallet-3A">Create wallet:</h4>
 
@@ -220,8 +189,7 @@ method and example responses.</p>
 <pre class="code ruby"><code class="ruby"><span class='const'><span class='object_link'><a href="Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Nanook.html#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span><span class='period'>.</span><span class='id identifier rubyid_wallet'><span class='object_link'><a href="Nanook.html#wallet-instance_method" title="Nanook#wallet (method)">wallet</a></span></span><span class='period'>.</span><span class='id identifier rubyid_restore'><span class='object_link'><a href="Nanook/Wallet.html#restore-instance_method" title="Nanook::Wallet#restore (method)">restore</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_seed'>seed</span><span class='rparen'>)</span>
 </code></pre>
 
-<p>Optionally also restore the wallet&#39;s accounts: <code>ruby
-Nanook.new.wallet.restore(seed, accounts: 2) </code></p>
+<p>Optionally also restore the wallet&#39;s accounts: <code>ruby Nanook.new.wallet.restore(seed, accounts: 2) </code></p>
 
 <h4 id="label-Working+with+a+single+wallet-3A">Working with a single wallet:</h4>
 
@@ -271,10 +239,7 @@ Nanook.new.wallet.restore(seed, accounts: 2) </code></p>
 
 <h4 id="label-Working+with+a+single+account-3A">Working with a single account:</h4>
 
-<p>See the <a
-href="https://lukes.github.io/nanook/2.5.0/Nanook/WalletAccount.html">full
-documentation for Nanook::WalletAccount</a> for a detailed description of
-each method and example responses.</p>
+<p>See the <a href="https://lukes.github.io/nanook/2.5.0/Nanook/WalletAccount.html">full documentation for Nanook::WalletAccount</a> for a detailed description of each method and example responses.</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_account'>account</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Nanook.html#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span><span class='period'>.</span><span class='id identifier rubyid_wallet'><span class='object_link'><a href="Nanook.html#wallet-instance_method" title="Nanook#wallet (method)">wallet</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_wallet_id'>wallet_id</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_account'><span class='object_link'><a href="Nanook/Wallet.html#account-instance_method" title="Nanook::Wallet#account (method)">account</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_account_id'>account_id</span><span class='rparen'>)</span>
 
@@ -313,10 +278,7 @@ each method and example responses.</p>
 
 <h4 id="label-Working+with+any+account+-28not+necessarily+in+your+wallet-29-3A">Working with any account (not necessarily in your wallet):</h4>
 
-<p>See the <a
-href="https://lukes.github.io/nanook/2.5.0/Nanook/Account.html">full
-documentation for Nanook::Account</a> for a detailed description of each
-method and example responses.</p>
+<p>See the <a href="https://lukes.github.io/nanook/2.5.0/Nanook/Account.html">full documentation for Nanook::Account</a> for a detailed description of each method and example responses.</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_account'>account</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Nanook.html#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span><span class='period'>.</span><span class='id identifier rubyid_account'><span class='object_link'><a href="Nanook.html#account-instance_method" title="Nanook#account (method)">account</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_account_id'>account_id</span><span class='rparen'>)</span>
 
@@ -348,10 +310,7 @@ method and example responses.</p>
 
 <h3 id="label-Blocks">Blocks</h3>
 
-<p>See the <a
-href="https://lukes.github.io/nanook/2.5.0/Nanook/Block.html">full
-documentation for Nanook::Block</a> for a detailed description of each
-method and example responses.</p>
+<p>See the <a href="https://lukes.github.io/nanook/2.5.0/Nanook/Block.html">full documentation for Nanook::Block</a> for a detailed description of each method and example responses.</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_block'>block</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Nanook.html#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span><span class='period'>.</span><span class='id identifier rubyid_block'><span class='object_link'><a href="Nanook.html#block-instance_method" title="Nanook#block (method)">block</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_block_id'>block_id</span><span class='rparen'>)</span>
 
@@ -382,10 +341,7 @@ method and example responses.</p>
 
 <h3 id="label-Managing+your+nano+node">Managing your nano node</h3>
 
-<p>See the <a
-href="https://lukes.github.io/nanook/2.5.0/Nanook/Node.html">full
-documentation for Nanook::Node</a> for a detailed description of each
-method and example responses.</p>
+<p>See the <a href="https://lukes.github.io/nanook/2.5.0/Nanook/Node.html">full documentation for Nanook::Node</a> for a detailed description of each method and example responses.</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_node'>node</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Nanook.html#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span><span class='period'>.</span><span class='id identifier rubyid_node'><span class='object_link'><a href="Nanook.html#node-instance_method" title="Nanook#node (method)">node</a></span></span>
 
@@ -438,23 +394,16 @@ method and example responses.</p>
 
 <h2 id="label-Nanook+Metal">Nanook Metal</h2>
 
-<p>You can do any call listed in the <a
-href="https://docs.nano.org/commands/rpc-protocol">Nano RPC</a> directly
-through the <code>rpc</code> method. The first argument should match the
-<code>action</code> of the RPC call, and then all remaining parameters are
-passed in as arguments.</p>
+<p>You can do any call listed in the <a href="https://docs.nano.org/commands/rpc-protocol">Nano RPC</a> directly through the <code>rpc</code> method. The first argument should match the <code>action</code> of the RPC call, and then all remaining parameters are passed in as arguments.</p>
 
-<p>E.g., the <a
-href="https://docs.nano.org/commands/rpc-protocol/#accounts_create">accounts_create
-command</a> can be called like this:</p>
+<p>E.g., the <a href="https://docs.nano.org/commands/rpc-protocol/#accounts_create">accounts_create command</a> can be called like this:</p>
 
 <pre class="code ruby"><code class="ruby"><span class='const'><span class='object_link'><a href="Nanook.html" title="Nanook (class)">Nanook</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Nanook.html#initialize-instance_method" title="Nanook#initialize (method)">new</a></span></span><span class='period'>.</span><span class='id identifier rubyid_rpc'><span class='object_link'><a href="Nanook.html#rpc-instance_method" title="Nanook#rpc (method)">rpc</a></span></span><span class='period'>.</span><span class='id identifier rubyid_call'><span class='object_link'><a href="Nanook/Rpc.html#call-instance_method" title="Nanook::Rpc#call (method)">call</a></span></span><span class='lparen'>(</span><span class='symbol'>:accounts_create</span><span class='comma'>,</span> <span class='label'>wallet:</span> <span class='id identifier rubyid_wallet_id'>wallet_id</span><span class='comma'>,</span> <span class='label'>count:</span> <span class='int'>2</span><span class='rparen'>)</span>
 </code></pre>
 
 <h2 id="label-Contributing">Contributing</h2>
 
-<p>Bug reports and pull requests are welcome. Pull requests with passing tests
-are even better.</p>
+<p>Bug reports and pull requests are welcome. Pull requests with passing tests are even better.</p>
 
 <p>To run the test suite:</p>
 
@@ -468,26 +417,22 @@ are even better.</p>
 
 <h2 id="label-License">License</h2>
 
-<p>The gem is available as open source under the terms of the <a
-href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
+<p>The gem is available as open source under the terms of the <a href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
 
 <h2 id="label-Buy+me+a+nano+coffee">Buy me a nano coffee</h2>
 
-<p>This library is totally free to use, but feel free to send some nano <a
-href="https://www.nanode.co/account/nano_3c3ek3k8135f6e8qtfy8eruk9q3yzmpebes7btzncccdest8ymzhjmnr196j">my
-way</a> if you&#39;d like to!</p>
+<p>This library is totally free to use, but feel free to send some nano <a href="https://www.nanode.co/account/nano_3c3ek3k8135f6e8qtfy8eruk9q3yzmpebes7btzncccdest8ymzhjmnr196j">my way</a> if you&#39;d like to!</p>
 
 <pre class="code ruby"><code class="ruby"><span class='id identifier rubyid_nano_3c3ek3k8135f6e8qtfy8eruk9q3yzmpebes7btzncccdest8ymzhjmnr196j'>nano_3c3ek3k8135f6e8qtfy8eruk9q3yzmpebes7btzncccdest8ymzhjmnr196j</span>
 </code></pre>
 
-<p><img
-src="https://raw.githubusercontent.com/lukes/nanook/master/img/qr.png"></p>
+<p><img src="https://raw.githubusercontent.com/lukes/nanook/master/img/qr.png"></p>
 </div></div>
 
       <div id="footer">
-  Generated on Mon Sep 16 06:30:33 2019 by
+  Generated on Fri Mar 26 12:47:23 2021 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.5.3).
+  0.9.24 (ruby-3.0.0).
 </div>
 
     </div>

--- a/docs/2.5.0/js/app.js
+++ b/docs/2.5.0/js/app.js
@@ -120,6 +120,49 @@ function summaryToggle() {
   } else { localStorage.summaryCollapsed = "expand"; }
 }
 
+function constantSummaryToggle() {
+  $('.constants_summary_toggle').click(function(e) {
+    e.preventDefault();
+    localStorage.summaryCollapsed = $(this).text();
+    $('.constants_summary_toggle').each(function() {
+      $(this).text($(this).text() == "collapse" ? "expand" : "collapse");
+      var next = $(this).parent().parent().nextAll('dl.constants').first();
+      if (next.hasClass('compact')) {
+        next.toggle();
+        next.nextAll('dl.constants').first().toggle();
+      }
+      else if (next.hasClass('constants')) {
+        var list = $('<dl class="constants compact" />');
+        list.html(next.html());
+        list.find('dt').each(function() {
+           $(this).addClass('summary_signature');
+           $(this).text( $(this).text().split('=')[0]);
+          if ($(this).has(".deprecated").length) {
+             $(this).addClass('deprecated');
+          };
+        });
+        // Add the value of the constant as "Tooltip" to the summary object
+        list.find('pre.code').each(function() {
+          console.log($(this).parent());
+          var dt_element = $(this).parent().prev();
+          var tooltip = $(this).text();
+          if (dt_element.hasClass("deprecated")) {
+             tooltip = 'Deprecated. ' + tooltip;
+          };
+          dt_element.attr('title', tooltip);
+        });
+        list.find('.docstring, .tags, dd').remove();
+        next.before(list);
+        next.toggle();
+      }
+    });
+    return false;
+  });
+  if (localStorage.summaryCollapsed == "collapse") {
+    $('.constants_summary_toggle').first().click();
+  } else { localStorage.summaryCollapsed = "expand"; }
+}
+
 function generateTOC() {
   if ($('#filecontents').length === 0) return;
   var _toc = $('<ol class="top"></ol>');
@@ -128,6 +171,7 @@ function generateTOC() {
   var counter = 0;
   var tags = ['h2', 'h3', 'h4', 'h5', 'h6'];
   var i;
+  var curli;
   if ($('#filecontents h1').length > 1) tags.unshift('h1');
   for (i = 0; i < tags.length; i++) { tags[i] = '#filecontents ' + tags[i]; }
   var lastTag = parseInt(tags[0][1], 10);
@@ -147,15 +191,25 @@ function generateTOC() {
     }
     if (thisTag > lastTag) {
       for (i = 0; i < thisTag - lastTag; i++) {
-        var tmp = $('<ol/>'); toc.append(tmp); toc = tmp;
+        if ( typeof(curli) == "undefined" ) {
+          curli = $('<li/>');
+          toc.append(curli);
+        }
+        toc = $('<ol/>');
+        curli.append(toc);
+        curli = undefined;
       }
     }
     if (thisTag < lastTag) {
-      for (i = 0; i < lastTag - thisTag; i++) toc = toc.parent();
+      for (i = 0; i < lastTag - thisTag; i++) {
+        toc = toc.parent();
+        toc = toc.parent();
+      }
     }
     var title = $(this).attr('toc-title');
     if (typeof(title) == "undefined") title = $(this).text();
-    toc.append('<li><a href="#' + this.id + '">' + title + '</a></li>');
+    curli =$('<li><a href="#' + this.id + '">' + title + '</a></li>'); 
+    toc.append(curli);
     lastTag = thisTag;
   });
   if (!show) return;
@@ -232,6 +286,16 @@ function mainFocus() {
   setTimeout(function() { $('#main').focus(); }, 10);
 }
 
+function navigationChange() {
+  // This works around the broken anchor navigation with the YARD template.
+  window.onpopstate = function() {
+    var hash = window.location.hash;
+    if (hash !== '' && $(hash)[0]) {
+      $(hash)[0].scrollIntoView();
+    }
+  };
+}
+
 $(document).ready(function() {
   navResizer();
   navExpander();
@@ -241,8 +305,10 @@ $(document).ready(function() {
   searchFrameButtons();
   linkSummaries();
   summaryToggle();
+  constantSummaryToggle();
   generateTOC();
   mainFocus();
+  navigationChange();
 });
 
 })();

--- a/docs/2.5.0/method_list.html
+++ b/docs/2.5.0/method_list.html
@@ -4,9 +4,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="utf-8" />
     
-      <link rel="stylesheet" href="css/full_list.css" type="text/css" media="screen" charset="utf-8" />
+      <link rel="stylesheet" href="css/full_list.css" type="text/css" media="screen" />
     
-      <link rel="stylesheet" href="css/common.css" type="text/css" media="screen" charset="utf-8" />
+      <link rel="stylesheet" href="css/common.css" type="text/css" media="screen" />
     
 
     
@@ -54,24 +54,24 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Wallet.html#account-instance_method" title="Nanook::Wallet#account (method)">#account</a></span>
-      <small>Nanook::Wallet</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Nanook.html#account-instance_method" title="Nanook#account (method)">#account</a></span>
       <small>Nanook</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Nanook/Block.html#account-instance_method" title="Nanook::Block#account (method)">#account</a></span>
       <small>Nanook::Block</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Nanook/Wallet.html#account-instance_method" title="Nanook::Wallet#account (method)">#account</a></span>
+      <small>Nanook::Wallet</small>
     </div>
   </li>
   
@@ -102,16 +102,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Account.html#balance-instance_method" title="Nanook::Account#balance (method)">#balance</a></span>
-      <small>Nanook::Account</small>
+      <span class='object_link'><a href="Nanook/Wallet.html#balance-instance_method" title="Nanook::Wallet#balance (method)">#balance</a></span>
+      <small>Nanook::Wallet</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Wallet.html#balance-instance_method" title="Nanook::Wallet#balance (method)">#balance</a></span>
-      <small>Nanook::Wallet</small>
+      <span class='object_link'><a href="Nanook/Account.html#balance-instance_method" title="Nanook::Account#balance (method)">#balance</a></span>
+      <small>Nanook::Account</small>
     </div>
   </li>
   
@@ -302,16 +302,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/WalletAccount.html#create-instance_method" title="Nanook::WalletAccount#create (method)">#create</a></span>
-      <small>Nanook::WalletAccount</small>
+      <span class='object_link'><a href="Nanook/Wallet.html#create-instance_method" title="Nanook::Wallet#create (method)">#create</a></span>
+      <small>Nanook::Wallet</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Wallet.html#create-instance_method" title="Nanook::Wallet#create (method)">#create</a></span>
-      <small>Nanook::Wallet</small>
+      <span class='object_link'><a href="Nanook/WalletAccount.html#create-instance_method" title="Nanook::WalletAccount#create (method)">#create</a></span>
+      <small>Nanook::WalletAccount</small>
     </div>
   </li>
   
@@ -334,16 +334,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/WalletAccount.html#delegators-instance_method" title="Nanook::WalletAccount#delegators (method)">#delegators</a></span>
-      <small>Nanook::WalletAccount</small>
+      <span class='object_link'><a href="Nanook/Account.html#delegators-instance_method" title="Nanook::Account#delegators (method)">#delegators</a></span>
+      <small>Nanook::Account</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Account.html#delegators-instance_method" title="Nanook::Account#delegators (method)">#delegators</a></span>
-      <small>Nanook::Account</small>
+      <span class='object_link'><a href="Nanook/WalletAccount.html#delegators-instance_method" title="Nanook::WalletAccount#delegators (method)">#delegators</a></span>
+      <small>Nanook::WalletAccount</small>
     </div>
   </li>
   
@@ -414,8 +414,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/WalletAccount.html#history-instance_method" title="Nanook::WalletAccount#history (method)">#history</a></span>
-      <small>Nanook::WalletAccount</small>
+      <span class='object_link'><a href="Nanook/Block.html#history-instance_method" title="Nanook::Block#history (method)">#history</a></span>
+      <small>Nanook::Block</small>
     </div>
   </li>
   
@@ -430,8 +430,40 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Block.html#history-instance_method" title="Nanook::Block#history (method)">#history</a></span>
+      <span class='object_link'><a href="Nanook/WalletAccount.html#history-instance_method" title="Nanook::WalletAccount#history (method)">#history</a></span>
+      <small>Nanook::WalletAccount</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Nanook/Key.html#id-instance_method" title="Nanook::Key#id (method)">#id</a></span>
+      <small>Nanook::Key</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Nanook/Block.html#id-instance_method" title="Nanook::Block#id (method)">#id</a></span>
       <small>Nanook::Block</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Nanook/Wallet.html#id-instance_method" title="Nanook::Wallet#id (method)">#id</a></span>
+      <small>Nanook::Wallet</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Nanook/Account.html#id-instance_method" title="Nanook::Account#id (method)">#id</a></span>
+      <small>Nanook::Account</small>
     </div>
   </li>
   
@@ -446,7 +478,7 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Key.html#id-instance_method" title="Nanook::Key#id (method)">#id</a></span>
+      <span class='object_link'><a href="Nanook/Key.html#info-instance_method" title="Nanook::Key#info (method)">#info</a></span>
       <small>Nanook::Key</small>
     </div>
   </li>
@@ -454,7 +486,7 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Block.html#id-instance_method" title="Nanook::Block#id (method)">#id</a></span>
+      <span class='object_link'><a href="Nanook/Block.html#info-instance_method" title="Nanook::Block#info (method)">#info</a></span>
       <small>Nanook::Block</small>
     </div>
   </li>
@@ -462,24 +494,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Wallet.html#id-instance_method" title="Nanook::Wallet#id (method)">#id</a></span>
+      <span class='object_link'><a href="Nanook/Wallet.html#info-instance_method" title="Nanook::Wallet#info (method)">#info</a></span>
       <small>Nanook::Wallet</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Nanook/Account.html#id-instance_method" title="Nanook::Account#id (method)">#id</a></span>
-      <small>Nanook::Account</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Nanook/Key.html#info-instance_method" title="Nanook::Key#info (method)">#info</a></span>
-      <small>Nanook::Key</small>
     </div>
   </li>
   
@@ -494,40 +510,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Block.html#info-instance_method" title="Nanook::Block#info (method)">#info</a></span>
-      <small>Nanook::Block</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Nanook/Wallet.html#info-instance_method" title="Nanook::Wallet#info (method)">#info</a></span>
-      <small>Nanook::Wallet</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Nanook/WalletAccount.html#info-instance_method" title="Nanook::WalletAccount#info (method)">#info</a></span>
       <small>Nanook::WalletAccount</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Nanook/WorkPeer.html#initialize-instance_method" title="Nanook::WorkPeer#initialize (method)">#initialize</a></span>
-      <small>Nanook::WorkPeer</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Nanook/Key.html#initialize-instance_method" title="Nanook::Key#initialize (method)">#initialize</a></span>
-      <small>Nanook::Key</small>
     </div>
   </li>
   
@@ -542,40 +526,24 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Node.html#initialize-instance_method" title="Nanook::Node#initialize (method)">#initialize</a></span>
-      <small>Nanook::Node</small>
+      <span class='object_link'><a href="Nanook/Key.html#initialize-instance_method" title="Nanook::Key#initialize (method)">#initialize</a></span>
+      <small>Nanook::Key</small>
     </div>
   </li>
   
 
   <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Nanook/Wallet.html#initialize-instance_method" title="Nanook::Wallet#initialize (method)">#initialize</a></span>
-      <small>Nanook::Wallet</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Nanook/Account.html#initialize-instance_method" title="Nanook::Account#initialize (method)">#initialize</a></span>
-      <small>Nanook::Account</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Nanook/WalletAccount.html#initialize-instance_method" title="Nanook::WalletAccount#initialize (method)">#initialize</a></span>
-      <small>Nanook::WalletAccount</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Nanook/Rpc.html#initialize-instance_method" title="Nanook::Rpc#initialize (method)">#initialize</a></span>
       <small>Nanook::Rpc</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Nanook/Node.html#initialize-instance_method" title="Nanook::Node#initialize (method)">#initialize</a></span>
+      <small>Nanook::Node</small>
     </div>
   </li>
   
@@ -590,56 +558,40 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook.html#inspect-instance_method" title="Nanook#inspect (method)">#inspect</a></span>
-      <small>Nanook</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Nanook/Block.html#inspect-instance_method" title="Nanook::Block#inspect (method)">#inspect</a></span>
-      <small>Nanook::Block</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Nanook/WalletAccount.html#inspect-instance_method" title="Nanook::WalletAccount#inspect (method)">#inspect</a></span>
-      <small>Nanook::WalletAccount</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Nanook/Wallet.html#inspect-instance_method" title="Nanook::Wallet#inspect (method)">#inspect</a></span>
+      <span class='object_link'><a href="Nanook/Wallet.html#initialize-instance_method" title="Nanook::Wallet#initialize (method)">#initialize</a></span>
       <small>Nanook::Wallet</small>
     </div>
   </li>
   
 
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Nanook/Account.html#initialize-instance_method" title="Nanook::Account#initialize (method)">#initialize</a></span>
+      <small>Nanook::Account</small>
+    </div>
+  </li>
+  
+
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Node.html#inspect-instance_method" title="Nanook::Node#inspect (method)">#inspect</a></span>
-      <small>Nanook::Node</small>
+      <span class='object_link'><a href="Nanook/WorkPeer.html#initialize-instance_method" title="Nanook::WorkPeer#initialize (method)">#initialize</a></span>
+      <small>Nanook::WorkPeer</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Rpc.html#inspect-instance_method" title="Nanook::Rpc#inspect (method)">#inspect</a></span>
-      <small>Nanook::Rpc</small>
+      <span class='object_link'><a href="Nanook/WalletAccount.html#initialize-instance_method" title="Nanook::WalletAccount#initialize (method)">#initialize</a></span>
+      <small>Nanook::WalletAccount</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Account.html#inspect-instance_method" title="Nanook::Account#inspect (method)">#inspect</a></span>
-      <small>Nanook::Account</small>
+      <span class='object_link'><a href="Nanook.html#inspect-instance_method" title="Nanook#inspect (method)">#inspect</a></span>
+      <small>Nanook</small>
     </div>
   </li>
   
@@ -654,8 +606,56 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Nanook/Rpc.html#inspect-instance_method" title="Nanook::Rpc#inspect (method)">#inspect</a></span>
+      <small>Nanook::Rpc</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Nanook/Node.html#inspect-instance_method" title="Nanook::Node#inspect (method)">#inspect</a></span>
+      <small>Nanook::Node</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Nanook/Block.html#inspect-instance_method" title="Nanook::Block#inspect (method)">#inspect</a></span>
+      <small>Nanook::Block</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Nanook/Wallet.html#inspect-instance_method" title="Nanook::Wallet#inspect (method)">#inspect</a></span>
+      <small>Nanook::Wallet</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Nanook/Account.html#inspect-instance_method" title="Nanook::Account#inspect (method)">#inspect</a></span>
+      <small>Nanook::Account</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Nanook/WorkPeer.html#inspect-instance_method" title="Nanook::WorkPeer#inspect (method)">#inspect</a></span>
       <small>Nanook::WorkPeer</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Nanook/WalletAccount.html#inspect-instance_method" title="Nanook::WalletAccount#inspect (method)">#inspect</a></span>
+      <small>Nanook::WalletAccount</small>
     </div>
   </li>
   
@@ -678,16 +678,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/WalletAccount.html#last_modified_at-instance_method" title="Nanook::WalletAccount#last_modified_at (method)">#last_modified_at</a></span>
-      <small>Nanook::WalletAccount</small>
+      <span class='object_link'><a href="Nanook/Account.html#last_modified_at-instance_method" title="Nanook::Account#last_modified_at (method)">#last_modified_at</a></span>
+      <small>Nanook::Account</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Account.html#last_modified_at-instance_method" title="Nanook::Account#last_modified_at (method)">#last_modified_at</a></span>
-      <small>Nanook::Account</small>
+      <span class='object_link'><a href="Nanook/WalletAccount.html#last_modified_at-instance_method" title="Nanook::WalletAccount#last_modified_at (method)">#last_modified_at</a></span>
+      <small>Nanook::WalletAccount</small>
     </div>
   </li>
   
@@ -742,16 +742,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/WalletAccount.html#pay-instance_method" title="Nanook::WalletAccount#pay (method)">#pay</a></span>
-      <small>Nanook::WalletAccount</small>
+      <span class='object_link'><a href="Nanook/Wallet.html#pay-instance_method" title="Nanook::Wallet#pay (method)">#pay</a></span>
+      <small>Nanook::Wallet</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Wallet.html#pay-instance_method" title="Nanook::Wallet#pay (method)">#pay</a></span>
-      <small>Nanook::Wallet</small>
+      <span class='object_link'><a href="Nanook/WalletAccount.html#pay-instance_method" title="Nanook::WalletAccount#pay (method)">#pay</a></span>
+      <small>Nanook::WalletAccount</small>
     </div>
   </li>
   
@@ -798,16 +798,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/WalletAccount.html#public_key-instance_method" title="Nanook::WalletAccount#public_key (method)">#public_key</a></span>
-      <small>Nanook::WalletAccount</small>
+      <span class='object_link'><a href="Nanook/Account.html#public_key-instance_method" title="Nanook::Account#public_key (method)">#public_key</a></span>
+      <small>Nanook::Account</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Account.html#public_key-instance_method" title="Nanook::Account#public_key (method)">#public_key</a></span>
-      <small>Nanook::Account</small>
+      <span class='object_link'><a href="Nanook/WalletAccount.html#public_key-instance_method" title="Nanook::WalletAccount#public_key (method)">#public_key</a></span>
+      <small>Nanook::WalletAccount</small>
     </div>
   </li>
   
@@ -846,16 +846,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/WalletAccount.html#representative-instance_method" title="Nanook::WalletAccount#representative (method)">#representative</a></span>
-      <small>Nanook::WalletAccount</small>
+      <span class='object_link'><a href="Nanook/Account.html#representative-instance_method" title="Nanook::Account#representative (method)">#representative</a></span>
+      <small>Nanook::Account</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Account.html#representative-instance_method" title="Nanook::Account#representative (method)">#representative</a></span>
-      <small>Nanook::Account</small>
+      <span class='object_link'><a href="Nanook/WalletAccount.html#representative-instance_method" title="Nanook::WalletAccount#representative (method)">#representative</a></span>
+      <small>Nanook::WalletAccount</small>
     </div>
   </li>
   
@@ -974,16 +974,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/WalletAccount.html#weight-instance_method" title="Nanook::WalletAccount#weight (method)">#weight</a></span>
-      <small>Nanook::WalletAccount</small>
+      <span class='object_link'><a href="Nanook/Account.html#weight-instance_method" title="Nanook::Account#weight (method)">#weight</a></span>
+      <small>Nanook::Account</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Nanook/Account.html#weight-instance_method" title="Nanook::Account#weight (method)">#weight</a></span>
-      <small>Nanook::Account</small>
+      <span class='object_link'><a href="Nanook/WalletAccount.html#weight-instance_method" title="Nanook::WalletAccount#weight (method)">#weight</a></span>
+      <small>Nanook::WalletAccount</small>
     </div>
   </li>
   

--- a/docs/2.5.0/top-level-namespace.html
+++ b/docs/2.5.0/top-level-namespace.html
@@ -10,11 +10,11 @@
   
 </title>
 
-  <link rel="stylesheet" href="css/style.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="css/style.css" type="text/css" />
 
-  <link rel="stylesheet" href="css/common.css" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="css/common.css" type="text/css" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = "";
   relpath = '';
 </script>
@@ -100,9 +100,9 @@
 </div>
 
       <div id="footer">
-  Generated on Mon Sep 16 06:30:33 2019 by
+  Generated on Fri Mar 26 12:47:23 2021 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.12 (ruby-2.5.3).
+  0.9.24 (ruby-3.0.0).
 </div>
 
     </div>

--- a/lib/nanook/util.rb
+++ b/lib/nanook/util.rb
@@ -6,14 +6,14 @@ class Nanook
   class Util
 
     # Constant used to convert back and forth between raw and NANO.
-    STEP = BigDecimal.new("10")**BigDecimal.new("30")
+    STEP = BigDecimal("10")**BigDecimal("30")
 
     # Converts an amount of NANO to an amount of raw.
     #
     # @param nano [Float|Integer] amount in nano
     # @return [Integer] amount in raw
     def self.NANO_to_raw(nano)
-      (BigDecimal.new(nano.to_s) * STEP).to_i
+      (BigDecimal(nano.to_s) * STEP).to_i
     end
 
     # Converts an amount of raw to an amount of NANO.


### PR DESCRIPTION
Hello!

This fixes #12. For new versions of BigDecimal, we cannot use BigDecimal.new().